### PR TITLE
Exposing the URLSession used by NetworkDataResourceService

### DIFF
--- a/Sources/TABResourceLoader/Operations/ResourceOperation.swift
+++ b/Sources/TABResourceLoader/Operations/ResourceOperation.swift
@@ -26,7 +26,7 @@ public final class ResourceOperation<T: ResourceServiceType>: BaseAsynchronousOp
   /// - parameter didFinishFetchingResourceCallback: The closure to be executed when the resource has been fetch but before the operation is finished
   ///
   /// - returns: A new instance of the ResourceOperation
-  public init(resource: ResourceService.Resource, service: ResourceService = ResourceService(), didFinishFetchingResourceCallback: @escaping DidFinishFetchingResourceCallback) {
+  public init(resource: ResourceService.Resource, service: ResourceService = ResourceService(session: URLSession.shared), didFinishFetchingResourceCallback: @escaping DidFinishFetchingResourceCallback) {
     self.resource = resource
     self.service = service
     self.didFinishFetchingResourceCallback = didFinishFetchingResourceCallback

--- a/Sources/TABResourceLoader/Protocols/ResourceServiceType.swift
+++ b/Sources/TABResourceLoader/Protocols/ResourceServiceType.swift
@@ -14,7 +14,7 @@ public protocol ResourceServiceType {
   /**
    Designated initialzer for constructing a ResourceServiceType
    */
-  init()
+  init(session: URLSessionType)
 
   /**
    Fetch a resource

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -38,7 +38,7 @@ open class NetworkDataResourceService<NetworkDataResource: NetworkResourceType &
   }
   
   /**
-   Designated initilizer for NetworkDataResourceService
+   Designated initializer for NetworkDataResourceService
    
    - returns: An new instance
    */
@@ -46,9 +46,14 @@ open class NetworkDataResourceService<NetworkDataResource: NetworkResourceType &
     self.session = URLSession.shared as URLSessionType
   }
   
-  let session: URLSessionType
+  public let session: URLSessionType
   
-  init(session: URLSessionType) {
+  /// Additional initializer allowing a custom `URLSessionType`.
+  ///
+  /// - parameter session: The session that will be used to make network requests.
+  ///
+  /// - returns: A new instance.
+  public init(session: URLSessionType) {
     self.session = session
   }
   

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -37,23 +37,16 @@ open class NetworkDataResourceService<NetworkDataResource: NetworkResourceType &
     return [:]
   }
   
+  public let session: URLSessionType
+  
   /**
    Designated initializer for NetworkDataResourceService
    
+   - parameter session: The session that will be used to make network requests.
+   
    - returns: An new instance
    */
-  public required init() {
-    self.session = URLSession.shared as URLSessionType
-  }
-  
-  public let session: URLSessionType
-  
-  /// Additional initializer allowing a custom `URLSessionType`.
-  ///
-  /// - parameter session: The session that will be used to make network requests.
-  ///
-  /// - returns: A new instance.
-  public init(session: URLSessionType) {
+  public required init(session: URLSessionType = URLSession.shared) {
     self.session = session
   }
   

--- a/Sources/TABResourceLoader/Services/URLSessionType.swift
+++ b/Sources/TABResourceLoader/Services/URLSessionType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol URLSessionType {
+public protocol URLSessionType {
   func perform(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void)
 }
 

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '3.0.1'
+  spec.version      = '3.0.2'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'

--- a/TABResourceLoader.xcodeproj/project.pbxproj
+++ b/TABResourceLoader.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.lucianomarisi.TABResourceLoader;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -752,6 +753,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.lucianomarisi.TABResourceLoader;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;

--- a/TABResourceLoader.xcodeproj/project.pbxproj
+++ b/TABResourceLoader.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		4FF005331DC9F985006BBACE /* ResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF005321DC9F985006BBACE /* ResourceType.swift */; };
 		4FF005351DC9F9E0006BBACE /* NetworkJSONArrayResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF005341DC9F9E0006BBACE /* NetworkJSONArrayResourceType.swift */; };
 		4FFA60A51D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFA60A41D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift */; };
+		EA80BE511E2798B300AA83F7 /* NetworkDataResourceServiceURLSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA80BE4F1E27985D00AA83F7 /* NetworkDataResourceServiceURLSessionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,6 +125,7 @@
 		4FF005321DC9F985006BBACE /* ResourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourceType.swift; sourceTree = "<group>"; };
 		4FF005341DC9F9E0006BBACE /* NetworkJSONArrayResourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkJSONArrayResourceType.swift; sourceTree = "<group>"; };
 		4FFA60A41D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkJSONDictionaryResourceType.swift; sourceTree = "<group>"; };
+		EA80BE4F1E27985D00AA83F7 /* NetworkDataResourceServiceURLSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkDataResourceServiceURLSessionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,7 +164,9 @@
 				4F079D1A1D84577E00D08DA0 /* Sources */,
 				4F079CE91D84566300D08DA0 /* Tests */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 			usesTabs = 0;
 		};
 		4F079CD01D84559100D08DA0 /* Products */ = {
@@ -311,6 +315,7 @@
 			isa = PBXGroup;
 			children = (
 				4F079D4D1D84599300D08DA0 /* ImageResourceTypeTests.swift */,
+				EA80BE4F1E27985D00AA83F7 /* NetworkDataResourceServiceURLSessionTests.swift */,
 				4F36C0B61D9D5B7E00CDFD21 /* JSONArrayResourceTypeTests.swift */,
 				4F36C0B31D9D5ABE00CDFD21 /* JSONDictionaryResourceTypeTests.swift */,
 				4F782C651DA2B10B00179638 /* NetworkJSONArrayResourceTypeTests.swift */,
@@ -569,6 +574,7 @@
 				4F079D741D8459D400D08DA0 /* NetworkDataResourceServiceTests.swift in Sources */,
 				4F079D6B1D8459D400D08DA0 /* MockObject.swift in Sources */,
 				4F079D671D8459D400D08DA0 /* MockJSONArrayResourceType.swift in Sources */,
+				EA80BE511E2798B300AA83F7 /* NetworkDataResourceServiceURLSessionTests.swift in Sources */,
 				4F079D6A1D8459D400D08DA0 /* MockNilURLRequestNetworkJSONResource.swift in Sources */,
 				4F079D681D8459D400D08DA0 /* MockJSONDictionaryResourceType.swift in Sources */,
 				4F079D6D1D8459D400D08DA0 /* MockResourceService.swift in Sources */,

--- a/Tests/TABResourceLoaderTests/Mocks/MockResourceService.swift
+++ b/Tests/TABResourceLoaderTests/Mocks/MockResourceService.swift
@@ -9,6 +9,12 @@
 import Foundation
 @testable import TABResourceLoader
 
+class MockSessionThatDoesNothing: URLSessionType {
+  func perform(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
+    // does nothing!
+  }
+}
+
 class MockResourceService: ResourceServiceType {
 
   typealias Resource = MockResource
@@ -17,7 +23,7 @@ class MockResourceService: ResourceServiceType {
   var capturedCompletion: ((Result<Resource.Model>) -> Void)?
   var fetchCallCount: Int = 0
 
-  required init() {}
+  required init(session: URLSessionType = MockSessionThatDoesNothing()) {}
 
   func fetch(resource: Resource, completion: @escaping (Result<Resource.Model>) -> Void) {
     capturedResource = resource

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkDataResourceServiceURLSessionTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkDataResourceServiceURLSessionTests.swift
@@ -1,0 +1,42 @@
+//
+//  NetworkDataResourceServiceURLSessionTests.swift
+//  TABResourceLoader
+//
+//  Created by Sam Dods on 12/01/2017.
+//  Copyright © 2017 Luciano Marisi. All rights reserved.
+//
+
+import XCTest
+import TABResourceLoader // note this is intentionally *not* @testable, so we can confirm URLSession is exposed
+
+class MockSessionToTestExposed: URLSessionType {
+  func perform(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
+    completion(Data(), nil, nil)
+  }
+}
+
+class NetworkDataResourceServiceURLSessionTests: XCTestCase {
+  
+  struct MockResource: NetworkResourceType, DataResourceType {
+    typealias Model = String
+    var url = URL(string: "test")!
+    func result(from data: Data) -> Result<Model> {
+      return .success("done")
+    }
+  }
+  
+  func test_initWithURLSession() {
+    let service = NetworkDataResourceService<MockResource>(session: MockSessionToTestExposed())
+    let resource = MockResource()
+    
+    var hasFetched = false
+    performAsyncTest { expectation in
+      service.fetch(resource: resource) { result in
+        hasFetched = true
+        expectation?.fulfill()
+      }
+    }
+    XCTAssertTrue(hasFetched)
+  }
+  
+}

--- a/Tests/TABResourceLoaderTests/Services/SubclassedNetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/SubclassedNetworkDataResourceServiceTests.swift
@@ -29,7 +29,7 @@ final class SubclassedNetworkDataResourceService<Resource: NetworkResourceType &
     super.init()
   }
 
-  override init(session: URLSessionType) {
+  override required init(session: URLSessionType) {
     super.init(session: session)
   }
 


### PR DESCRIPTION
This allows a custom (or mock) session to be used