### PR TITLE
Issue 10 Network activity indicator out of memory fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0
 
 - Added support for listen to network activity changes, useful for setting up `isNetworkActivityIndicatorVisible` on `UIApplication`
+- `fetch(resource: Resource, completion: @escaping (Result<Resource.Model>) -> Void)` method on `NetworkDataResourceService` is now `open` for overriding
 
 ## 3.0.3
 

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -59,8 +59,8 @@ open class NetworkDataResourceService<NetworkDataResource: NetworkResourceType &
     urlRequest.allHTTPHeaderFields = allHTTPHeaderFields(resourceHTTPHeaderFields: urlRequest.allHTTPHeaderFields)
     NetworkServiceActivity.increaseActiveRequest()
     session.perform(request: urlRequest) { [weak self] (data, URLResponse, error) in
-      guard let strongSelf = self else { return }
       NetworkServiceActivity.decreaseActiveRequest()
+      guard let strongSelf = self else { return }
       completion(strongSelf.resultFrom(resource: resource, data: data, URLResponse: URLResponse, error: error))
     }
   }

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -50,7 +50,7 @@ open class NetworkDataResourceService<NetworkDataResource: NetworkResourceType &
     self.session = session
   }
 
-  public final func fetch(resource: Resource, completion: @escaping (Result<Resource.Model>) -> Void) {
+  open func fetch(resource: Resource, completion: @escaping (Result<Resource.Model>) -> Void) {
     fetch(resource: resource, networkServiceActivity: NetworkServiceActivity.shared, completion: completion)
   }
 

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -49,17 +49,22 @@ open class NetworkDataResourceService<NetworkDataResource: NetworkResourceType &
   public required init(session: URLSessionType = URLSession.shared) {
     self.session = session
   }
-  
+
   public final func fetch(resource: Resource, completion: @escaping (Result<Resource.Model>) -> Void) {
+    fetch(resource: resource, networkServiceActivity: NetworkServiceActivity.shared, completion: completion)
+  }
+
+  // Method used for injecting the NetworkServiceActivity for testing
+  final func fetch(resource: Resource, networkServiceActivity: NetworkServiceActivity, completion: @escaping (Result<Resource.Model>) -> Void) {
     guard var urlRequest = resource.urlRequest() else {
       completion(.failure(NetworkServiceError.couldNotCreateURLRequest))
       return
     }
     
     urlRequest.allHTTPHeaderFields = allHTTPHeaderFields(resourceHTTPHeaderFields: urlRequest.allHTTPHeaderFields)
-    NetworkServiceActivity.increaseActiveRequest()
+    networkServiceActivity.increaseActiveRequest()
     session.perform(request: urlRequest) { [weak self] (data, URLResponse, error) in
-      NetworkServiceActivity.decreaseActiveRequest()
+      networkServiceActivity.decreaseActiveRequest()
       guard let strongSelf = self else { return }
       completion(strongSelf.resultFrom(resource: resource, data: data, URLResponse: URLResponse, error: error))
     }

--- a/Sources/TABResourceLoader/Services/NetworkServiceActivity.swift
+++ b/Sources/TABResourceLoader/Services/NetworkServiceActivity.swift
@@ -10,30 +10,32 @@ import Foundation
 
 /// Type used to expose an API to listen to activity changes of network calls, i.e whether network 
 // calls are being made or not
-public struct NetworkServiceActivity {
+public class NetworkServiceActivity {
 
   /// Set this property to listen to changes on the network activity status,
   /// useful for setting the isNetworkActivityIndicatorVisible on UIApplication for example
   public static var activityChangeHandler: ((_ isActive: Bool) -> ())?
 
-  private static var numberOfActiveRequests = 0 {
+  static let shared = NetworkServiceActivity()
+
+  private(set)var numberOfActiveRequests = 0 {
     didSet {
       let hasOutstandingRequests = numberOfActiveRequests > 0
-      activityChangeHandler?(hasOutstandingRequests)
+      NetworkServiceActivity.activityChangeHandler?(hasOutstandingRequests)
     }
   }
 
-  private static let serialQueue = DispatchQueue(label: "TABResourceLoader.NetworkServiceActivity.serialQueue")
+  private let serialQueue = DispatchQueue(label: "TABResourceLoader.NetworkServiceActivity.serialQueue")
 
   /// Call this method every time a request starts
-  static func increaseActiveRequest() {
+  func increaseActiveRequest() {
     serialQueue.sync {
       numberOfActiveRequests += 1
     }
   }
   
   /// Call this method every time a request ends
-  static func decreaseActiveRequest() {
+  func decreaseActiveRequest() {
     serialQueue.sync {
       numberOfActiveRequests -= 1
     }

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -49,7 +49,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
     XCTAssertEqual(capturedRequest, expectedRequest)
   }
 
-  func test_fetch_fetchIncresesAndCompletionDecreaseNumberOfActiveRequests() {
+  func test_fetch_incresesAndCompletionDecreaseNumberOfActiveRequests() {
     XCTAssertEqual(mockNetworkServiceActivity.numberOfActiveRequests, 0)
     testService.fetch(resource: mockResource, networkServiceActivity: mockNetworkServiceActivity) { _ in }
     XCTAssertEqual(mockNetworkServiceActivity.numberOfActiveRequests, 1)
@@ -57,7 +57,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
     XCTAssertEqual(mockNetworkServiceActivity.numberOfActiveRequests, 0)
   }
 
-  func test_fetchIncresesAndCompletionDecreaseNumberOfActiveRequests_evenWhenServiceGoesOutOfMemory() {
+  func test_fetch_incresesAndCompletionDecreaseNumberOfActiveRequests_evenWhenServiceGoesOutOfMemory() {
     let mockNetworkServiceActivity = MockNetworkServiceActivity()
     XCTAssertEqual(mockNetworkServiceActivity.numberOfActiveRequests, 0)
     testService.fetch(resource: mockResource, networkServiceActivity: mockNetworkServiceActivity) { _ in }


### PR DESCRIPTION
This fixes the issue when the service goes out of memory before the session completes.