### PR TITLE
ResourceServiceType now uses a generic result type

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -52,7 +52,7 @@ class ViewController: UIViewController {
     }
 
     let imageOperation = NetworkImageResourceOperation(resource: imageResource) { [weak self] _, result in
-      if case let .success(image) = result {
+      if case let .success(image, _) = result {
         self?.imageView.image = image
       }
     }

--- a/Sources/TABResourceLoader/Operations/ResourceOperation.swift
+++ b/Sources/TABResourceLoader/Operations/ResourceOperation.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Operation used for the sole purpose of fetching a resource using a service
 public final class ResourceOperation<ResourceService: ResourceServiceType>: BaseAsynchronousOperation {
 
-  public typealias DidFinishFetchingResourceCallback = (ResourceOperation<ResourceService>, Result<ResourceService.Resource.Model>) -> Void
+  public typealias DidFinishFetchingResourceCallback = (ResourceOperation<ResourceService>, ResourceService.ResultType) -> Void
 
   // These properties are internal for unit testing purposes
   let resource: ResourceService.Resource
@@ -51,7 +51,7 @@ public final class ResourceOperation<ResourceService: ResourceServiceType>: Base
     super.cancel()
   }
 
-  private func handleFetchCompletion(with result: Result<ResourceService.Resource.Model>) {
+  private func handleFetchCompletion(with result: ResourceService.ResultType) {
     Thread.rl_executeOnMain { [weak self] in
       guard let strongSelf = self else { return }
       if strongSelf.isCancelled { return }

--- a/Sources/TABResourceLoader/Protocols/ResourceServiceType.swift
+++ b/Sources/TABResourceLoader/Protocols/ResourceServiceType.swift
@@ -10,24 +10,27 @@ import Foundation
 
 /// Defines a type that can be cancelled
 public protocol Cancellable: class {
+  /// Cancels this task
   func cancel()
 }
 
 /// Defines a type that can fetch resources
 public protocol ResourceServiceType {
+  /// Defines the type of resource that this service fetches
   associatedtype Resource: ResourceType
 
-  /**
-   Designated initialzer for constructing a ResourceServiceType
-   */
+  /// Defines the type of result that this service returns
+  associatedtype ResultType
+
+  /// Designated initialzer for constructing a ResourceServiceType
   init()
 
-  /**
-   Fetch a resource
-
-   - parameter resource:   The resource to fetch
-   - parameter completion: A completion handler called with a Result type of the fetching computation
-   */
+  /// Fetch a resource
+  ///
+  /// - Parameters:
+  ///   - resource: The resource to fetch
+  ///   - completion: A completion handler called with a Result type of the fetching computation
+  /// - Returns: A cancellable type if it's possible to cancel the task created
   @discardableResult
-  func fetch(resource: Resource, completion: @escaping (Result<Resource.Model>) -> Void) -> Cancellable?
+  func fetch(resource: Resource, completion: @escaping (ResultType) -> Void) -> Cancellable?
 }

--- a/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
@@ -11,6 +11,7 @@ import Foundation
 open class GenericNetworkDataResourceService<NetworkDataResource: NetworkResourceType & DataResourceType>: NetworkDataResourceService, ResourceServiceType {
 
   public typealias Resource = NetworkDataResource
+  public typealias ResultType = NetworkResponse<Resource.Model>
 
   /// Designated initializer for NetworkDataResourceService, uses the shared URLSession
   public required init() {

--- a/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
+++ b/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
@@ -8,31 +8,82 @@
 
 import Foundation
 
+/// Enum representing the response from a network request
+///
+/// ---
+/// # Success case
+///
+/// Defines a response that succeeded containing:
+///   - The parsed model
+///   - The HTTPURLResponse
+///
+/// ## A success will meet all the following conditions:
+///   - The parsing succeeds
+///   - The HTTP status code is not 4xx or 5xx
+///   - No error returned from URLSession
+///
+/// ---
+/// # Failure case
+///
+/// Defines a response that failed, contains:
+///   - The Result of parsing the model, success case contains the model and failure case contains the parsing error
+///   - A HTTPURLResponse if it exists
+///   - A NetworkServiceError
+///
+/// ## Reasons for failure can be (in order):
+///   1. No HTTPURLResponse with a URLSession error
+///   2. No HTTPURLResponse without a URLSession error (This can only be possible for non HTTP responses)
+///   3. The HTTP status code is 4xx or 5xx
+///   4. A URLSession error exists
+///   5. Could not parse the data
+public enum NetworkResponse<Model> {
+  case success(Model, HTTPURLResponse)
+  case failure(Result<Model>, HTTPURLResponse?, NetworkServiceError)
+}
+
+enum NetworkResponseHandlerError: Error {
+  case noDataProvided
+}
+
 struct NetworkResponseHandler {
 
-  static func resultFrom<Resource: NetworkResourceType & DataResourceType>(resource: Resource, data: Data?, URLResponse: Foundation.URLResponse?, error: Error?) -> Result<Resource.Model> {
+  static func resultFrom<Resource: NetworkResourceType & DataResourceType>(resource: Resource, data: Data?, URLResponse: Foundation.URLResponse?, error: Error?) -> NetworkResponse<Resource.Model> {
 
-    if let HTTPURLResponse = URLResponse as? HTTPURLResponse {
-      switch HTTPURLResponse.statusCode {
-      case 400..<600:
-        return .failure(NetworkServiceError.statusCodeError(statusCode: HTTPURLResponse.statusCode))
-      default: break
+    let parsedResult = transform(data, using: resource)
+
+    guard let HTTPURLResponse = URLResponse as? HTTPURLResponse else {
+      if let error = error {
+        return .failure(parsedResult, nil, .sessionError(error: error))
+      } else {
+        return .failure(parsedResult, nil, .noHTTPURLResponse)
       }
     }
 
+    switch HTTPURLResponse.statusCode {
+    case 400..<600:
+      return .failure(parsedResult, HTTPURLResponse, .statusCodeError(statusCode: HTTPURLResponse.statusCode))
+    default: break
+    }
+
     if let error = error {
-      return .failure(NetworkServiceError.networkingError(error: error))
+      return .failure(parsedResult, HTTPURLResponse, .sessionError(error: error))
     }
 
-    guard let data = data else {
-      return .failure(NetworkServiceError.noData)
-    }
-
-    do {
-      let model = try resource.model(from: data)
-      return .success(model)
-    } catch {
-      return .failure(error)
+    switch parsedResult {
+    case .success(let model):
+      return .success(model, HTTPURLResponse)
+    case .failure(let parsingError):
+       return .failure(parsedResult, HTTPURLResponse, .couldNotParseData(error: parsingError))
     }
   }
+
+  private static func transform<Resource: DataResourceType>(_ data: Data?, using resource: Resource) -> Result<Resource.Model> {
+    guard let data = data else {
+      return .failure(NetworkResponseHandlerError.noDataProvided)
+    }
+    return Result<Resource.Model> {
+      return try resource.model(from: data)
+    }
+  }
+
 }

--- a/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
+++ b/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
@@ -49,7 +49,7 @@ struct NetworkResponseHandler {
 
   static func resultFrom<Resource: NetworkResourceType & DataResourceType>(resource: Resource, data: Data?, URLResponse: Foundation.URLResponse?, error: Error?) -> NetworkResponse<Resource.Model> {
 
-    let parsedResult = transform(data, using: resource)
+    let parsedResult = self.parsedResult(transformedFrom: data, using: resource)
 
     guard let HTTPURLResponse = URLResponse as? HTTPURLResponse else {
       if let error = error {
@@ -77,7 +77,7 @@ struct NetworkResponseHandler {
     }
   }
 
-  private static func transform<Resource: DataResourceType>(_ data: Data?, using resource: Resource) -> Result<Resource.Model> {
+  private static func parsedResult<Resource: DataResourceType>(transformedFrom data: Data?, using resource: Resource) -> Result<Resource.Model> {
     guard let data = data else {
       return .failure(NetworkResponseHandlerError.noDataProvided)
     }

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -73,13 +73,16 @@ class NetworkDataResourceServiceTests: XCTestCase {
     XCTAssertNil(mockInvalidURLResource.urlRequest())
     performAsyncTest { expectation in
       newTestRequestManager.fetch(resource: mockInvalidURLResource) { result in
-        expectation?.fulfill()
-        guard let error = result.error() else {
+        switch result {
+        case .success:
           XCTFail("No error found")
-          return
+        case .failure(_, _, let error):
+          guard case NetworkServiceError.couldNotCreateURLRequest = error else {
+            XCTFail("Unexpected error: \(error)")
+            return
+          }
         }
-        if case NetworkServiceError.couldNotCreateURLRequest = error { return }
-        XCTFail("Unexpected error: \(error)")
+        expectation?.fulfill()
       }
     }
   }
@@ -98,19 +101,34 @@ class NetworkDataResourceServiceTests: XCTestCase {
     let mockHTTPURLResponse = HTTPURLResponse(url: URL(string: "www.test.com")!, statusCode: expectedStatusCode, httpVersion: nil, headerFields: nil)
     performAsyncTest(file: file, lineNumber: lineNumber) { expectation in
       testService.fetch(resource: mockResource) { result in
-        expectation?.fulfill()
-        guard let error = result.error() else {
+        switch result {
+        case .success:
           XCTFail("No error found")
-          return
+        case .failure(_, _, let error):
+          guard case NetworkServiceError.statusCodeError(let statusCode) = error else {
+            XCTFail("Unexpected error: \(error)")
+            return
+          }
+          XCTAssertEqual(statusCode, expectedStatusCode)
+          expectation?.fulfill()
         }
-
-        guard case NetworkServiceError.statusCodeError(let statusCode) = error else {
-          XCTFail()
-          return
-        }
-        XCTAssert(statusCode == expectedStatusCode)
       }
       mockSession.capturedCompletion!(nil, mockHTTPURLResponse, expectedError)
+    }
+  }
+
+  func test_fetch_whenSessionCompletesDataAndHTTPURLResponse_callsSuccess() {
+    performAsyncTest { expectation in
+      testService.fetch(resource: mockResource) { result in
+        switch result {
+        case .success(let model, _):
+          XCTAssertEqual(model, "")
+          expectation?.fulfill()
+        case .failure(_, _, let error):
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+      mockSession.capturedCompletion!(Data(), HTTPURLResponse(), nil)
     }
   }
 
@@ -126,17 +144,17 @@ class NetworkDataResourceServiceTests: XCTestCase {
     let mockHTTPURLResponse = HTTPURLResponse(url: URL(string: "www.test.com")!, statusCode: expectedStatusCode, httpVersion: nil, headerFields: nil)
     performAsyncTest(file: file, lineNumber: lineNumber) { expectation in
       testService.fetch(resource: mockResource) { result in
-        expectation?.fulfill()
-        guard let error = result.error() else {
+        switch result {
+        case .success:
           XCTFail("No error found")
-          return
+        case .failure(_, _, let error):
+          guard case NetworkServiceError.sessionError(let testError) = error else {
+            XCTFail("Unexpected error: \(error)")
+            return
+          }
+          XCTAssertEqual(testError._domain, expectedError._domain)
+          expectation?.fulfill()
         }
-
-        guard case NetworkServiceError.networkingError(let testError) = error else {
-          XCTFail()
-          return
-        }
-        XCTAssert(testError._domain == expectedError._domain)
       }
       mockSession.capturedCompletion!(nil, mockHTTPURLResponse, expectedError)
     }
@@ -147,17 +165,17 @@ class NetworkDataResourceServiceTests: XCTestCase {
 
     performAsyncTest { expectation in
       testService.fetch(resource: mockResource) { result in
-        expectation?.fulfill()
-        guard let error = result.error() else {
+        switch result {
+        case .success:
           XCTFail("No error found")
-          return
+        case .failure(_, _, let error):
+          guard case NetworkServiceError.sessionError(let testError) = error else {
+            XCTFail("Unexpected error: \(error)")
+            return
+          }
+          XCTAssertEqual(testError._domain, expectedError._domain)
+          expectation?.fulfill()
         }
-
-        guard case NetworkServiceError.networkingError(let testError) = error else {
-          XCTFail()
-          return
-        }
-        XCTAssert(testError._domain == expectedError._domain)
       }
       mockSession.capturedCompletion!(nil, nil, expectedError)
     }
@@ -166,15 +184,18 @@ class NetworkDataResourceServiceTests: XCTestCase {
   func test_fetch_whenSessionCompletes_WithNoData_callsFailureWithCorrectError() {
     performAsyncTest { expectation in
       testService.fetch(resource: mockResource) { result in
-        expectation?.fulfill()
-        guard let error = result.error() else {
+        switch result {
+        case .success:
           XCTFail("No error found")
-          return
+        case .failure(_, _, let error):
+          guard case NetworkServiceError.couldNotParseData(error: NetworkResponseHandlerError.noDataProvided) = error else {
+            XCTFail("Unexpected error: \(error)")
+            return
+          }
+          expectation?.fulfill()
         }
-        if case NetworkServiceError.noData = error { return }
-        XCTFail()
       }
-      mockSession.capturedCompletion!(nil, nil, nil)
+      mockSession.capturedCompletion!(nil, HTTPURLResponse(), nil)
     }
   }
 


### PR DESCRIPTION
- Introduce NetworkResponse as the result of NetworkDataResourceService

The `NetworkResponse` contains the complete response in a strongly typed manner. Would be good to get some discussion on whether this object is too complex and/or if it's missing some information.

Before merging we'll need to add a few more unit tests for the updated business logic of handling the response from the `URLSessionTask`.