### PR TITLE
Prepare for v4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 4.0.0
 
-- `DataResourceType`, `JSONDictionaryResourceType` and `JSONArrayResourceType` now throw on failure
-- Renamed function on `DataResourceType` from `func result(from data: Data) -> Result<Model>` to `func model(from data: Data) throws -> Model`
+1. `DataResourceType`, `JSONDictionaryResourceType` and `JSONArrayResourceType` transformation functions now throw on failure instead of returning `Result<Model>`
 - Refactored network service
 	- Renamed `NetworkDataResourceService` to `GenericNetworkDataResourceService`, this is useful when using it with `ResourceOperation`
 	- New `NetworkDataResourceService` uses a generic fetching function
+	- `NetworkDataResourceService` now uses `NetworkResponse` as the result type in the completion handler
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## 4.0.0
 
-1. `DataResourceType`, `JSONDictionaryResourceType` and `JSONArrayResourceType` transformation functions now throw on failure instead of returning `Result<Model>`
+- `DataResourceType` transformation function now throws on failure instead of returning `Result<Model>`:
+
+	```swift
+	// Old interface
+	func result(from data: Data) -> Result<Model>
+	// New interface
+	func model(from data: Data) throws -> Model
+	```
+	
+- `JSONDictionaryResourceType` transformation function now throws on failure instead of returning `Model?`:
+
+	```swift
+	// Old interface
+	func model(from jsonDictionary: [String : Any]) -> Model?
+	// New interface
+	func model(from jsonDictionary: [String : Any]) throws -> Model
+	```
+
+- `JSONArrayResourceType` transformation function now throws on failure instead of returning `Model?`:
+
+	```swift
+	// Old interface
+	func model(from jsonArray: [Any]) -> Model?
+	// New interface
+	func model(from jsonArray: [Any]) throws -> Model
+	```
+	
 - Refactored network service
 	- Renamed `NetworkDataResourceService` to `GenericNetworkDataResourceService`, this is useful when using it with `ResourceOperation`
 	- New `NetworkDataResourceService` uses a generic fetching function

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '3.2.0'
+  spec.version      = '4.0.0'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'


### PR DESCRIPTION
Added reference to `NetworkResponse` in CHANGELOG and updated podspec.