### PR TITLE
Simplified failed network response error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+
+## 5.0.0
+
+- The error from a failed `NetworkResponse` is now flattened to avoid nested switch statements: 
+
+```swift
+enum NetworkResponse<Model> {
+  case success(Model, HTTPURLResponse)
+  case failure(parsingError: Error?, NetworkServiceError, HTTPURLResponse?)
+}
+```
+
 ## 4.0.0
 
 - `DataResourceType` transformation function now throws on failure instead of returning `Result<Model>`:

--- a/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
@@ -11,7 +11,7 @@ import Foundation
 open class GenericNetworkDataResourceService<NetworkDataResource: NetworkResourceType & DataResourceType>: NetworkDataResourceService, ResourceServiceType {
 
   public typealias Resource = NetworkDataResource
-  public typealias ResultType = NetworkResponse<Resource.Model>
+  public typealias ResultType = NetworkResponseSingleError<Resource.Model>
 
   /// Designated initializer for NetworkDataResourceService, uses the shared URLSession
   public required init() {

--- a/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
@@ -11,7 +11,7 @@ import Foundation
 open class GenericNetworkDataResourceService<NetworkDataResource: NetworkResourceType & DataResourceType>: NetworkDataResourceService, ResourceServiceType {
 
   public typealias Resource = NetworkDataResource
-  public typealias ResultType = NetworkResponseSingleError<Resource.Model>
+  public typealias ResultType = NetworkResponseMultipleError<Resource.Model>
 
   /// Designated initializer for NetworkDataResourceService, uses the shared URLSession
   public required init() {

--- a/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
@@ -11,7 +11,7 @@ import Foundation
 open class GenericNetworkDataResourceService<NetworkDataResource: NetworkResourceType & DataResourceType>: NetworkDataResourceService, ResourceServiceType {
 
   public typealias Resource = NetworkDataResource
-  public typealias ResultType = NetworkResponseMultipleError<Resource.Model>
+  public typealias ResultType = NetworkResponse<Resource.Model>
 
   /// Designated initializer for NetworkDataResourceService, uses the shared URLSession
   public required init() {

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -40,8 +40,7 @@ public enum NetworkServiceError: Error {
   case noHTTPURLResponse
   case sessionError(error: Error)
   case statusCodeError(statusCode: Int)
-  case couldNotParseData(error: Error) // Could not parse model?
-  case noDataProvided
+  case couldNotParseData(error: Error)
 }
 
 /// Object used to retrive types that conform to both @NetworkResourceType and DataResourceType

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -80,14 +80,14 @@ open class NetworkDataResourceService {
    - parameter completion: A completion handler called with a Result type of the fetching computation
    */
   @discardableResult
-  open func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, completion: @escaping (NetworkResponseMultipleError<Resource.Model>) -> Void) -> Cancellable? {
+  open func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, completion: @escaping (NetworkResponse<Resource.Model>) -> Void) -> Cancellable? {
     let cancellable = fetch(resource: resource, networkServiceActivity: NetworkServiceActivity.shared, completion: completion)
     return cancellable
   }
 
   // Method used for injecting the NetworkServiceActivity for testing
   @discardableResult
-  func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, networkServiceActivity: NetworkServiceActivity, completion: @escaping (NetworkResponseMultipleError<Resource.Model>) -> Void) -> Cancellable? {
+  func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, networkServiceActivity: NetworkServiceActivity, completion: @escaping (NetworkResponse<Resource.Model>) -> Void) -> Cancellable? {
     guard var urlRequest = resource.urlRequest() else {
       completion(.failure(parsingError: nil, .couldNotCreateURLRequest, nil))
       return nil

--- a/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
+++ b/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
@@ -46,17 +46,8 @@ public enum NetworkResponseMultipleError<Model> {
   case failure(parsingError: Error?, NetworkServiceError, HTTPURLResponse?)
 }
 
-public enum NetworkResponseSingleError<Model> {
-  case success(Model, HTTPURLResponse)
-  case failure(Error, HTTPURLResponse?)
-}
-
 enum NetworkResponseHandlerError: Error {
   case noDataProvided
-}
-
-public protocol ErrorResourceType {
-  func error(from data: Data) -> Error?
 }
 
 struct NetworkResponseHandler {

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '4.0.0'
+  spec.version      = '5.0.0'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -76,7 +76,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.couldNotCreateURLRequest = error else {
             XCTFail("Unexpected error: \(error)")
             return
@@ -104,9 +104,9 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.statusCodeError(let statusCode) = error else {
-            XCTFail("Unexpected error: \(error)")
+            XCTFail("Unexpected error: \(error)", file: file, line: lineNumber)
             return
           }
           XCTAssertEqual(statusCode, expectedStatusCode)
@@ -124,7 +124,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         case .success(let model, _):
           XCTAssertEqual(model, "")
           expectation?.fulfill()
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           XCTFail("Unexpected error: \(error)")
         }
       }
@@ -147,9 +147,9 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.sessionError(let testError) = error else {
-            XCTFail("Unexpected error: \(error)")
+            XCTFail("Unexpected error: \(error)", file: file, line: lineNumber)
             return
           }
           XCTAssertEqual(testError._domain, expectedError._domain)
@@ -168,7 +168,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.sessionError(let testError) = error else {
             XCTFail("Unexpected error: \(error)")
             return
@@ -187,7 +187,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.couldNotParseData(error: NetworkResponseHandlerError.noDataProvided) = error else {
             XCTFail("Unexpected error: \(error)")
             return


### PR DESCRIPTION
When using V4 we noticed that having nested switch statements was not ideal from an API point of view so we flattened the parsing of an error response into an `Error`. This replace the `Result<Model>` part of the `NetworkResponse`