### PR TITLE
Simplified failed network response error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: generic
 osx_image: xcode8.3
 script:
   - xcrun instruments -t 'Blank' -l 10 -w "iPhone 6s (10.3)"
-  - xcodebuild -scheme Example -configuration Debug -sdk iphonesimulator10.0 -destination "OS=10.3,name=iPhone 6s" build
-  - xcodebuild -scheme TABResourceLoader -configuration Debug -sdk iphonesimulator10.0 -destination "OS=10.3,name=iPhone 6s" test -enableCodeCoverage YES
+  - xcodebuild -scheme Example -configuration Debug -sdk iphonesimulator10.3 -destination "OS=10.3,name=iPhone 6s" build
+  - xcodebuild -scheme TABResourceLoader -configuration Debug -sdk iphonesimulator10.3 -destination "OS=10.3,name=iPhone 6s" test -enableCodeCoverage YES
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
 language: generic
 osx_image: xcode8.3
 script:
-  - xcrun instruments -t 'Blank' -l 10 -w "iPhone 6s (10.3)"
+  # - xcrun instruments -t 'Blank' -l 10 -w "iPhone 6s (10.3)"
   - xcodebuild -scheme Example -configuration Debug -sdk iphonesimulator10.3 -destination "OS=10.3,name=iPhone 6s" build
   - xcodebuild -scheme TABResourceLoader -configuration Debug -sdk iphonesimulator10.3 -destination "OS=10.3,name=iPhone 6s" test -enableCodeCoverage YES
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 os:
   - osx
 language: generic
-osx_image: xcode8
+osx_image: xcode8.3
 script:
-  - xcrun instruments -t 'Blank' -l 10 -w "iPhone 6s (10.0)"
-  - xcodebuild -scheme Example -configuration Debug -sdk iphonesimulator10.0 -destination "OS=10.0,name=iPhone 6s" build
-  - xcodebuild -scheme TABResourceLoader -configuration Debug -sdk iphonesimulator10.0 -destination "OS=10.0,name=iPhone 6s" test -enableCodeCoverage YES
+  - xcrun instruments -t 'Blank' -l 10 -w "iPhone 6s (10.3)"
+  - xcodebuild -scheme Example -configuration Debug -sdk iphonesimulator10.0 -destination "OS=10.3,name=iPhone 6s" build
+  - xcodebuild -scheme TABResourceLoader -configuration Debug -sdk iphonesimulator10.0 -destination "OS=10.3,name=iPhone 6s" test -enableCodeCoverage YES
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 
 ## 5.0.0
 
-- The error from a failed `NetworkResponse` is now flattened to avoid nested switch statements: 
+- The error from a failed `NetworkResponse` is now flattened and moved into the `NetworkServiceError` `couldNotParseModel` case to avoid nested switch statements: 
 
 ```swift
 enum NetworkResponse<Model> {
   case success(Model, HTTPURLResponse)
-  case failure(parsingError: Error?, NetworkServiceError, HTTPURLResponse?)
+  case failure(NetworkServiceError, HTTPURLResponse?)
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+
+## 5.0.0
+
+- The error from a failed `NetworkResponse` is now flattened to avoid nested switch statements: 
+
+```swift
+enum NetworkResponse<Model> {
+  case success(Model, HTTPURLResponse)
+  case failure(parsingError: Error?, NetworkServiceError, HTTPURLResponse?)
+}
+```
+
 ## 4.0.0
 
 - `DataResourceType` transformation function now throws on failure instead of returning `Result<Model>`:

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -85,12 +85,8 @@ class ViewController: UIViewController {
       switch result {
       case .success(let successResult, _):
         self?.handleRegistrationResult(successResult)
-      case .failure(let registrationResult, _, let error):
-        if case let .success(errorResult) = registrationResult {
-          self?.handleRegistrationResult(errorResult)
-        } else {
-          print(error)
-        }
+      case .failure(let error, _):
+        print(error)
       }
 
     }

--- a/Sources/TABResourceLoader/Protocols/Resource types/DataResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/DataResourceType.swift
@@ -37,4 +37,12 @@ public protocol DataResourceType: ResourceType {
    - returns: An instantiated model if parsing was successful, otherwise throws
    */
   func model(from data: Data) throws -> Model
+
+  func error(from data: Data) -> Error?
+}
+
+public extension DataResourceType {
+  func error(from data: Data) -> Error? {
+    return nil
+  }
 }

--- a/Sources/TABResourceLoader/Protocols/Resource types/DataResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/DataResourceType.swift
@@ -38,9 +38,17 @@ public protocol DataResourceType: ResourceType {
    */
   func model(from data: Data) throws -> Model
 
+  /**
+   Optionally returns an error from the data provided
+   
+   - parameter data: The data to parse
+   
+   - returns: An error from the data
+   */
   func error(from data: Data) -> Error?
 }
 
+// No errors are returned by default
 public extension DataResourceType {
   func error(from data: Data) -> Error? {
     return nil

--- a/Sources/TABResourceLoader/Protocols/Resource types/JSONArrayResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/JSONArrayResourceType.swift
@@ -40,11 +40,25 @@ public protocol JSONArrayResourceType: DataResourceType {
    - returns: An instantiated model if parsing was successful, otherwise throws
    */
   func model(from jsonArray: [Any]) throws -> Model
+
+  func error(from jsonArray: [Any]) -> Error?
 }
 
 extension JSONArrayResourceType {
 
   public func model(from data: Data) throws -> Model {
+    let jsonArray = try self.jsonArray(from: data)
+    return try model(from: jsonArray)
+  }
+
+  public func error(from data: Data) -> Error? {
+    guard let jsonArray = try? self.jsonArray(from: data) else {
+      return nil
+    }
+    return error(from: jsonArray)
+  }
+
+  private func jsonArray(from data: Data) throws -> [Any] {
     guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) else {
       throw JSONParsingError.invalidJSONData
     }
@@ -52,8 +66,13 @@ extension JSONArrayResourceType {
     guard let jsonArray = jsonObject as? [Any] else {
       throw JSONParsingError.notAJSONArray
     }
-
-    return try model(from: jsonArray)
+    return jsonArray
   }
 
+}
+
+public extension JSONArrayResourceType {
+  func error(from jsonArray: [Any]) -> Error? {
+    return nil
+  }
 }

--- a/Sources/TABResourceLoader/Protocols/Resource types/JSONArrayResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/JSONArrayResourceType.swift
@@ -41,6 +41,14 @@ public protocol JSONArrayResourceType: DataResourceType {
    */
   func model(from jsonArray: [Any]) throws -> Model
 
+
+  /**
+   Optionally returns an error from the JSON array provided
+   
+   - parameter jsonArray: The JSON array to parse
+   
+   - returns: An error from the jsonArray
+   */
   func error(from jsonArray: [Any]) -> Error?
 }
 
@@ -71,6 +79,7 @@ extension JSONArrayResourceType {
 
 }
 
+// No errors are returned by default
 public extension JSONArrayResourceType {
   func error(from jsonArray: [Any]) -> Error? {
     return nil

--- a/Sources/TABResourceLoader/Protocols/Resource types/JSONArrayResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/JSONArrayResourceType.swift
@@ -41,7 +41,6 @@ public protocol JSONArrayResourceType: DataResourceType {
    */
   func model(from jsonArray: [Any]) throws -> Model
 
-
   /**
    Optionally returns an error from the JSON array provided
    

--- a/Sources/TABResourceLoader/Protocols/Resource types/JSONDictionaryResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/JSONDictionaryResourceType.swift
@@ -40,11 +40,25 @@ public protocol JSONDictionaryResourceType: DataResourceType {
    - returns: An instantiated model if parsing was successful, otherwise throws
    */
   func model(from jsonDictionary: [String : Any]) throws -> Model
+
+  func error(from jsonDictionary: [String : Any]) -> Error?
 }
 
 extension JSONDictionaryResourceType {
 
   public func model(from data: Data) throws -> Model {
+    let jsonDictionary = try self.jsonDictionary(from: data)
+    return try model(from: jsonDictionary)
+  }
+
+  public func error(from data: Data) -> Error? {
+    guard let jsonDictionary = try? self.jsonDictionary(from: data) else {
+      return nil
+    }
+    return error(from: jsonDictionary)
+  }
+
+  public func jsonDictionary(from data: Data) throws ->  [String : Any] {
     guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) else {
       throw JSONParsingError.invalidJSONData
     }
@@ -53,7 +67,13 @@ extension JSONDictionaryResourceType {
       throw JSONParsingError.notAJSONDictionary
     }
 
-    return try model(from: jsonDictionary)
+    return jsonDictionary
   }
 
+}
+
+public extension JSONDictionaryResourceType {
+  func error(from jsonDictionary: [String : Any]) -> Error? {
+    return nil
+  }
 }

--- a/Sources/TABResourceLoader/Protocols/Resource types/JSONDictionaryResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/JSONDictionaryResourceType.swift
@@ -41,6 +41,13 @@ public protocol JSONDictionaryResourceType: DataResourceType {
    */
   func model(from jsonDictionary: [String : Any]) throws -> Model
 
+  /**
+   Optionally returns an error from the JSON dictionary provided
+   
+   - parameter jsonDictionary: The JSON dictionary to parse
+   
+   - returns: An error from the jsonDictionary
+   */
   func error(from jsonDictionary: [String : Any]) -> Error?
 }
 
@@ -72,6 +79,7 @@ extension JSONDictionaryResourceType {
 
 }
 
+// No errors are returned by default
 public extension JSONDictionaryResourceType {
   func error(from jsonDictionary: [String : Any]) -> Error? {
     return nil

--- a/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
@@ -11,7 +11,7 @@ import Foundation
 open class GenericNetworkDataResourceService<NetworkDataResource: NetworkResourceType & DataResourceType>: NetworkDataResourceService, ResourceServiceType {
 
   public typealias Resource = NetworkDataResource
-  public typealias ResultType = NetworkResponse<Resource.Model>
+  public typealias ResultType = NetworkResponseSingleError<Resource.Model>
 
   /// Designated initializer for NetworkDataResourceService, uses the shared URLSession
   public required init() {

--- a/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
@@ -11,7 +11,7 @@ import Foundation
 open class GenericNetworkDataResourceService<NetworkDataResource: NetworkResourceType & DataResourceType>: NetworkDataResourceService, ResourceServiceType {
 
   public typealias Resource = NetworkDataResource
-  public typealias ResultType = NetworkResponseSingleError<Resource.Model>
+  public typealias ResultType = NetworkResponseMultipleError<Resource.Model>
 
   /// Designated initializer for NetworkDataResourceService, uses the shared URLSession
   public required init() {

--- a/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/GenericNetworkDataResourceService.swift
@@ -11,7 +11,7 @@ import Foundation
 open class GenericNetworkDataResourceService<NetworkDataResource: NetworkResourceType & DataResourceType>: NetworkDataResourceService, ResourceServiceType {
 
   public typealias Resource = NetworkDataResource
-  public typealias ResultType = NetworkResponseMultipleError<Resource.Model>
+  public typealias ResultType = NetworkResponse<Resource.Model>
 
   /// Designated initializer for NetworkDataResourceService, uses the shared URLSession
   public required init() {

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -40,8 +40,7 @@ public enum NetworkServiceError: Error {
   case noHTTPURLResponse
   case sessionError(error: Error)
   case statusCodeError(statusCode: Int)
-  case couldNotParseData(error: Error) // Could not parse model?
-  case noDataProvided
+  case couldNotParseData(error: Error)
 }
 
 /// Object used to retrive types that conform to both @NetworkResourceType and DataResourceType

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -34,13 +34,15 @@ import Foundation
 /// - noHTTPURLResponse:        No HTTPURLResponse exists
 /// - sessionError:             The networking error returned by the URLSession
 /// - statusCodeError:          A status code error between 400 and 600 (not including 600) was returned
-/// - couldNotParseData:        The Data could not be parsed
+/// - noDataProvided:           No data was returned
+/// - couldNotParseModel:       Could not parse Model from the response
 public enum NetworkServiceError: Error {
   case couldNotCreateURLRequest
   case noHTTPURLResponse
   case sessionError(error: Error)
   case statusCodeError(statusCode: Int)
-  case couldNotParseData(error: Error)
+  case noDataProvided
+  case couldNotParseModel(error: Error)
 }
 
 /// Object used to retrive types that conform to both @NetworkResourceType and DataResourceType
@@ -89,7 +91,7 @@ open class NetworkDataResourceService {
   @discardableResult
   func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, networkServiceActivity: NetworkServiceActivity, completion: @escaping (NetworkResponse<Resource.Model>) -> Void) -> Cancellable? {
     guard var urlRequest = resource.urlRequest() else {
-      completion(.failure(parsingError: nil, .couldNotCreateURLRequest, nil))
+      completion(.failure(.couldNotCreateURLRequest, nil))
       return nil
     }
 

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -80,14 +80,14 @@ open class NetworkDataResourceService {
    - parameter completion: A completion handler called with a Result type of the fetching computation
    */
   @discardableResult
-  open func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, completion: @escaping (NetworkResponseMultipleError<Resource.Model>) -> Void) -> Cancellable? {
+  open func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, completion: @escaping (NetworkResponse<Resource.Model>) -> Void) -> Cancellable? {
     let cancellable = fetch(resource: resource, networkServiceActivity: NetworkServiceActivity.shared, completion: completion)
     return cancellable
   }
 
   // Method used for injecting the NetworkServiceActivity for testing
   @discardableResult
-  func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, networkServiceActivity: NetworkServiceActivity, completion: @escaping (NetworkResponseMultipleError<Resource.Model>) -> Void) -> Cancellable? {
+  func fetch<Resource: NetworkResourceType & DataResourceType>(resource: Resource, networkServiceActivity: NetworkServiceActivity, completion: @escaping (NetworkResponse<Resource.Model>) -> Void) -> Cancellable? {
     guard var urlRequest = resource.urlRequest() else {
       completion(.failure(parsingError: nil, .couldNotCreateURLRequest, nil))
       return nil

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -42,7 +42,7 @@ public enum NetworkServiceError: Error {
   case sessionError(error: Error)
   case statusCodeError(statusCode: Int)
   case noDataProvided
-  case statusCodeCustomError(error: Error)
+  case statusCodeCustomError(statusCode: Int, error: Error)
 }
 
 /// Object used to retrive types that conform to both @NetworkResourceType and DataResourceType

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -35,14 +35,14 @@ import Foundation
 /// - sessionError:             The networking error returned by the URLSession
 /// - statusCodeError:          A status code error between 400 and 600 (not including 600) was returned
 /// - noDataProvided:           No data was returned
-/// - couldNotParseModel:       Could not parse Model from the response
+/// - statusCodeCustomError:    Contains the custom error for failed status code
 public enum NetworkServiceError: Error {
   case couldNotCreateURLRequest
   case noHTTPURLResponse
   case sessionError(error: Error)
   case statusCodeError(statusCode: Int)
   case noDataProvided
-  case couldNotParseModel(error: Error)
+  case statusCodeCustomError(error: Error)
 }
 
 /// Object used to retrive types that conform to both @NetworkResourceType and DataResourceType

--- a/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
+++ b/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
@@ -70,7 +70,7 @@ struct NetworkResponseHandler {
       }
     default:
       if let error = resource.error(from: data) {
-        return .failure(.statusCodeCustomError(error: error), HTTPURLResponse)
+        return .failure(.statusCodeCustomError(statusCode: HTTPURLResponse.statusCode, error: error), HTTPURLResponse)
       } else {
         return .failure(.statusCodeError(statusCode: HTTPURLResponse.statusCode), HTTPURLResponse)
       }

--- a/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
+++ b/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
@@ -46,17 +46,8 @@ public enum NetworkResponseMultipleError<Model> {
   case failure(parsingError: Error?, NetworkServiceError, HTTPURLResponse?)
 }
 
-public enum NetworkResponseSingleError<Model> {
-  case success(Model, HTTPURLResponse)
-  case failure(Error, HTTPURLResponse?)
-}
-
 enum NetworkResponseHandlerError: Error {
   case noDataProvided
-}
-
-public protocol ErrorResourceType {
-  func error(from data: Data) -> Error?
 }
 
 struct NetworkResponseHandler {

--- a/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
+++ b/Sources/TABResourceLoader/Services/NetworkResponseHandler.swift
@@ -70,7 +70,7 @@ struct NetworkResponseHandler {
       }
     default:
       if let error = resource.error(from: data) {
-        return .failure(.couldNotParseModel(error: error), HTTPURLResponse)
+        return .failure(.statusCodeCustomError(error: error), HTTPURLResponse)
       } else {
         return .failure(.statusCodeError(statusCode: HTTPURLResponse.statusCode), HTTPURLResponse)
       }

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '4.0.0'
+  spec.version      = '5.0.0'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'

--- a/TABResourceLoader.xcodeproj/project.pbxproj
+++ b/TABResourceLoader.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		4F36C0B21D9D52A700CDFD21 /* JSONArrayResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F36C0B11D9D52A700CDFD21 /* JSONArrayResourceType.swift */; };
 		4F36C0B51D9D5AE400CDFD21 /* JSONDictionaryResourceTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F36C0B31D9D5ABE00CDFD21 /* JSONDictionaryResourceTypeTests.swift */; };
 		4F36C0B81D9D5BD200CDFD21 /* JSONArrayResourceTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F36C0B61D9D5B7E00CDFD21 /* JSONArrayResourceTypeTests.swift */; };
+		4F4BE52A1ECB40AC00C2CC56 /* NetworkResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4BE5291ECB40AC00C2CC56 /* NetworkResponseHandlerTests.swift */; };
+		4F4BE52C1ECB415500C2CC56 /* String+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4BE52B1ECB415500C2CC56 /* String+Error.swift */; };
 		4F57E88C1E5DFDEB0082DF87 /* MultipleResponseResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F57E88B1E5DFDEB0082DF87 /* MultipleResponseResource.swift */; };
 		4F57E8901E5E000E0082DF87 /* CitiesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F57E88F1E5E000E0082DF87 /* CitiesResponse.swift */; };
 		4F57E8921E5E007B0082DF87 /* ServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F57E8911E5E007B0082DF87 /* ServerError.swift */; };
@@ -119,6 +121,8 @@
 		4F36C0B11D9D52A700CDFD21 /* JSONArrayResourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONArrayResourceType.swift; sourceTree = "<group>"; };
 		4F36C0B31D9D5ABE00CDFD21 /* JSONDictionaryResourceTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDictionaryResourceTypeTests.swift; sourceTree = "<group>"; };
 		4F36C0B61D9D5B7E00CDFD21 /* JSONArrayResourceTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONArrayResourceTypeTests.swift; sourceTree = "<group>"; };
+		4F4BE5291ECB40AC00C2CC56 /* NetworkResponseHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResponseHandlerTests.swift; sourceTree = "<group>"; };
+		4F4BE52B1ECB415500C2CC56 /* String+Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Error.swift"; sourceTree = "<group>"; };
 		4F57E88B1E5DFDEB0082DF87 /* MultipleResponseResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleResponseResource.swift; sourceTree = "<group>"; };
 		4F57E88F1E5E000E0082DF87 /* CitiesResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CitiesResponse.swift; sourceTree = "<group>"; };
 		4F57E8911E5E007B0082DF87 /* ServerError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerError.swift; sourceTree = "<group>"; };
@@ -315,6 +319,7 @@
 			children = (
 				4F079D781D84650800D08DA0 /* ImageMocker.swift */,
 				4F079D3F1D84599300D08DA0 /* XCTestCase+Additions.swift */,
+				4F4BE52B1ECB415500C2CC56 /* String+Error.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -362,6 +367,7 @@
 			children = (
 				4F079D521D84599300D08DA0 /* NetworkDataResourceServiceTests.swift */,
 				4F079D531D84599300D08DA0 /* SubclassedNetworkDataResourceServiceTests.swift */,
+				4F4BE5291ECB40AC00C2CC56 /* NetworkResponseHandlerTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -633,6 +639,7 @@
 				4FB4D6D51D8476B000A7D1B8 /* ResourceOperation.swift in Sources */,
 				4F079D2D1D84577E00D08DA0 /* NetworkResourceType.swift in Sources */,
 				4F079D371D84585E00D08DA0 /* NSThread+Additions.swift in Sources */,
+				4F4BE52C1ECB415500C2CC56 /* String+Error.swift in Sources */,
 				4F88C6971D88A122002CAEA2 /* Result.swift in Sources */,
 				4F079D281D84577E00D08DA0 /* BaseAsynchronousOperation.swift in Sources */,
 				4F079D2C1D84577E00D08DA0 /* JSONParsingError.swift in Sources */,
@@ -679,6 +686,7 @@
 				4F079D6A1D8459D400D08DA0 /* MockNilURLRequestNetworkJSONResource.swift in Sources */,
 				4F079D681D8459D400D08DA0 /* MockJSONDictionaryResourceType.swift in Sources */,
 				4F6CDC191E5AF5B7001BF320 /* GlobalFunctionsTests.swift in Sources */,
+				4F4BE52A1ECB40AC00C2CC56 /* NetworkResponseHandlerTests.swift in Sources */,
 				4F079D6D1D8459D400D08DA0 /* MockResourceService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/TABResourceLoaderTests/Helpers/String+Error.swift
+++ b/Tests/TABResourceLoaderTests/Helpers/String+Error.swift
@@ -1,0 +1,12 @@
+//
+//  String+Error.swift
+//  TABResourceLoader
+//
+//  Created by Luciano Marisi on 16/05/2017.
+//  Copyright © 2017 Luciano Marisi. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Convenience extension for mocking errors in unit tests
+extension String: Error {}

--- a/Tests/TABResourceLoaderTests/Protocols/JSONArrayResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/JSONArrayResourceTypeTests.swift
@@ -60,4 +60,9 @@ class JSONArrayResourceTypeTests: XCTestCase {
     XCTAssertEqual(result, expectedMockObjectsArray)
   }
 
+  func test_defaultErrorIsNil() {
+    let mockJSONArrayResourceType = MockJSONArrayResourceType()
+    XCTAssertNil(mockJSONArrayResourceType.error(from: []))
+  }
+
 }

--- a/Tests/TABResourceLoaderTests/Protocols/JSONDictionaryResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/JSONDictionaryResourceTypeTests.swift
@@ -57,4 +57,9 @@ class JSONDictionaryResourceTypeTests: XCTestCase {
     XCTAssertEqual(calculatedMockObject, expectedMockObject)
   }
 
+  func test_defaultErrorIsNil() {
+    let mockJSONObjectResourceType = MockJSONDictionaryResourceType()
+    XCTAssertNil(mockJSONObjectResourceType.error(from: [:]))
+  }
+
 }

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -76,7 +76,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, let error, _):
+        case .failure(let error, _):
           guard case NetworkServiceError.couldNotCreateURLRequest = error else {
             XCTFail("Unexpected error: \(error)")
             return
@@ -104,7 +104,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, let error, _):
+        case .failure(let error, _):
           guard case NetworkServiceError.statusCodeError(let statusCode) = error else {
             XCTFail("Unexpected error: \(error)", file: file, line: lineNumber)
             return
@@ -124,11 +124,12 @@ class NetworkDataResourceServiceTests: XCTestCase {
         case .success(let model, _):
           XCTAssertEqual(model, "")
           expectation?.fulfill()
-        case .failure(_, let error, _):
+        case .failure(let error, _):
           XCTFail("Unexpected error: \(error)")
         }
       }
-      mockSession.capturedCompletion!(Data(), HTTPURLResponse(), nil)
+      let successResponse = HTTPURLResponse(url: mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+      mockSession.capturedCompletion!(Data(), successResponse, nil)
     }
   }
 
@@ -147,7 +148,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, let error, _):
+        case .failure(let error, _):
           guard case NetworkServiceError.sessionError(let testError) = error else {
             XCTFail("Unexpected error: \(error)", file: file, line: lineNumber)
             return
@@ -168,7 +169,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, let error, _):
+        case .failure(let error, _):
           guard case NetworkServiceError.sessionError(let testError) = error else {
             XCTFail("Unexpected error: \(error)")
             return
@@ -187,8 +188,8 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, let error, _):
-          guard case NetworkServiceError.couldNotParseData(error: NetworkResponseHandlerError.noDataProvided) = error else {
+        case .failure(let error, _):
+          guard case NetworkServiceError.noDataProvided = error else {
             XCTFail("Unexpected error: \(error)")
             return
           }

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -76,7 +76,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.couldNotCreateURLRequest = error else {
             XCTFail("Unexpected error: \(error)")
             return
@@ -104,9 +104,9 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.statusCodeError(let statusCode) = error else {
-            XCTFail("Unexpected error: \(error)")
+            XCTFail("Unexpected error: \(error)", file: file, line: lineNumber)
             return
           }
           XCTAssertEqual(statusCode, expectedStatusCode)
@@ -124,7 +124,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         case .success(let model, _):
           XCTAssertEqual(model, "")
           expectation?.fulfill()
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           XCTFail("Unexpected error: \(error)")
         }
       }
@@ -147,9 +147,9 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.sessionError(let testError) = error else {
-            XCTFail("Unexpected error: \(error)")
+            XCTFail("Unexpected error: \(error)", file: file, line: lineNumber)
             return
           }
           XCTAssertEqual(testError._domain, expectedError._domain)
@@ -168,7 +168,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.sessionError(let testError) = error else {
             XCTFail("Unexpected error: \(error)")
             return
@@ -187,7 +187,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
         switch result {
         case .success:
           XCTFail("No error found")
-        case .failure(_, _, let error):
+        case .failure(_, let error, _):
           guard case NetworkServiceError.couldNotParseData(error: NetworkResponseHandlerError.noDataProvided) = error else {
             XCTFail("Unexpected error: \(error)")
             return

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -117,7 +117,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
     }
   }
 
-  func test_fetch_whenSessionCompletesDataAndHTTPURLResponse_callsSuccess() {
+  func test_fetch_whenSessionCompletesDataAndHTTPURLResponse_callsSuccessWhenParsingSucceed() {
     performAsyncTest { expectation in
       testService.fetch(resource: mockResource) { result in
         switch result {

--- a/Tests/TABResourceLoaderTests/Services/NetworkResponseHandlerTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkResponseHandlerTests.swift
@@ -53,10 +53,11 @@ class NetworkResponseHandlerTests: XCTestCase {
     let successResponse = HTTPURLResponse(url: mockURL, statusCode: 504, httpVersion: nil, headerFields: nil)
     let response = NetworkResponseHandler.resultFrom(resource: MockErrorResponseResource(), data: Data(), URLResponse: successResponse, error: nil)
     guard case NetworkResponse.failure(let error, let urlResponse) = response,
-          case NetworkServiceError.statusCodeCustomError(let errorModel) = error else {
+          case NetworkServiceError.statusCodeCustomError(let statusCode, let errorModel) = error else {
         XCTFail("Unexpected response: \(response)")
         return
     }
+    XCTAssertEqual(statusCode, 504)
     XCTAssertEqual(errorModel as? String, "Parsing error failed")
     XCTAssertEqual(successResponse, urlResponse)
   }

--- a/Tests/TABResourceLoaderTests/Services/NetworkResponseHandlerTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkResponseHandlerTests.swift
@@ -1,0 +1,75 @@
+//
+//  NetworkResponseHandlerTests.swift
+//  TABResourceLoader
+//
+//  Created by Luciano Marisi on 16/05/2017.
+//  Copyright © 2017 Luciano Marisi. All rights reserved.
+//
+
+import XCTest
+@testable import TABResourceLoader
+
+struct MockParsingFailedResource: NetworkResourceType, DataResourceType {
+  typealias Model = String
+  let url: URL = URL(string: "http://test.com")!
+
+  func model(from data: Data) throws -> String {
+    throw "Parsing failed"
+  }
+
+}
+
+struct MockErrorResponseResource: NetworkResourceType, DataResourceType {
+  typealias Model = String
+  let url: URL = URL(string: "http://test.com")!
+
+  func model(from data: Data) throws -> String {
+    return "Success"
+  }
+
+  func error(from data: Data) -> Error? {
+    return "Parsing error failed"
+  }
+
+}
+
+class NetworkResponseHandlerTests: XCTestCase {
+
+  let mockURL = URL(string: "http://test.com")!
+
+  func test_resultIsStatusCodeFailureWhenModelParsingFailsForSuccessfullStatusCodes() {
+    let successResponse = HTTPURLResponse(url: mockURL, statusCode: 204, httpVersion: nil, headerFields: nil)
+    let response = NetworkResponseHandler.resultFrom(resource: MockParsingFailedResource(), data: Data(), URLResponse: successResponse, error: nil)
+    guard case NetworkResponse.failure(let error, let urlResponse) = response,
+          case NetworkServiceError.statusCodeError(let statusCode) = error else {
+        XCTFail()
+        return
+    }
+    XCTAssertEqual(statusCode, 204)
+    XCTAssertEqual(successResponse, urlResponse)
+  }
+
+  func test_resultIsCouldNotParseModelWhenErrorParsingSucceedsForErrorStatusCodes() {
+    let successResponse = HTTPURLResponse(url: mockURL, statusCode: 504, httpVersion: nil, headerFields: nil)
+    let response = NetworkResponseHandler.resultFrom(resource: MockErrorResponseResource(), data: Data(), URLResponse: successResponse, error: nil)
+    guard case NetworkResponse.failure(let error, let urlResponse) = response,
+          case NetworkServiceError.couldNotParseModel(let errorModel) = error else {
+        XCTFail("Unexpected response: \(response)")
+        return
+    }
+    XCTAssertEqual(errorModel as? String, "Parsing error failed")
+    XCTAssertEqual(successResponse, urlResponse)
+  }
+
+  func test_resultIsStatusCodeFailureWhenErrorParsingFailsForErrorStatusCodes() {
+    let successResponse = HTTPURLResponse(url: mockURL, statusCode: 504, httpVersion: nil, headerFields: nil)
+    let response = NetworkResponseHandler.resultFrom(resource: MockParsingFailedResource(), data: Data(), URLResponse: successResponse, error: nil)
+    guard case NetworkResponse.failure(let error, let urlResponse) = response,
+          case NetworkServiceError.statusCodeError(let statusCode) = error else {
+        XCTFail("Unexpected response: \(response)")
+        return
+    }
+    XCTAssertEqual(statusCode, 504)
+    XCTAssertEqual(successResponse, urlResponse)
+  }
+}

--- a/Tests/TABResourceLoaderTests/Services/NetworkResponseHandlerTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkResponseHandlerTests.swift
@@ -49,11 +49,11 @@ class NetworkResponseHandlerTests: XCTestCase {
     XCTAssertEqual(successResponse, urlResponse)
   }
 
-  func test_resultIsCouldNotParseModelWhenErrorParsingSucceedsForErrorStatusCodes() {
+  func test_resultIsStatusCodeCustomErrorWhenErrorParsingSucceedsForErrorStatusCodes() {
     let successResponse = HTTPURLResponse(url: mockURL, statusCode: 504, httpVersion: nil, headerFields: nil)
     let response = NetworkResponseHandler.resultFrom(resource: MockErrorResponseResource(), data: Data(), URLResponse: successResponse, error: nil)
     guard case NetworkResponse.failure(let error, let urlResponse) = response,
-          case NetworkServiceError.couldNotParseModel(let errorModel) = error else {
+          case NetworkServiceError.statusCodeCustomError(let errorModel) = error else {
         XCTFail("Unexpected response: \(response)")
         return
     }


### PR DESCRIPTION
Combined the error from failed response into the `NetworkServiceError` for simplicity.

Related and closed PR #50 