### PR TITLE
Remove Questionmark from URLs with no QueryItems

### DIFF
--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -93,9 +93,9 @@ public extension NetworkResourceType {
   }
 
   private func allQueryItems(initialItems: [URLQueryItem]?) -> [URLQueryItem]? {
-    let allQueryItems = (initialItems ?? []) + (queryItems ?? [])
-    let final = allQueryItems.isEmpty ? nil : allQueryItems
-    return final
+    let combinedQueryItems = (initialItems ?? []) + (queryItems ?? [])
+    let allQueryItems = combinedQueryItems.isEmpty ? nil : combinedQueryItems
+    return allQueryItems
   }
 }
 

--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -77,7 +77,7 @@ public extension NetworkResourceType {
 
   public func urlRequest() -> URLRequest? {
     var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
-    urlComponents?.queryItems = allQueryItems()
+    urlComponents?.queryItems = allQueryItems(initialItems: urlComponents?.queryItems)
 
     guard let urlFromComponents = urlComponents?.url else { return nil }
 
@@ -92,19 +92,10 @@ public extension NetworkResourceType {
     return request
   }
 
-  private func allQueryItems() -> [URLQueryItem] {
-    var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
-    var allQueryItems = [URLQueryItem]()
-
-    if let componentsQueryItems = urlComponents?.queryItems {
-      allQueryItems.append(contentsOf: componentsQueryItems)
-    }
-
-    if let queryItems = queryItems {
-      allQueryItems.append(contentsOf: queryItems)
-    }
-
-    return allQueryItems
+  private func allQueryItems(initialItems: [URLQueryItem]?) -> [URLQueryItem]? {
+    let allQueryItems = (initialItems ?? []) + (queryItems ?? [])
+    let final = allQueryItems.isEmpty ? nil : allQueryItems
+    return final
   }
 }
 

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -69,6 +69,14 @@ class NetworkResourceTypeTests: XCTestCase {
     XCTAssertEqual(urlRequest?.url?.absoluteString, urlWithQueryParameters.absoluteString)
   }
 
+  func test_urlRequest_resourceURLWithNoQueryItemsHasNoQuestionMark() {
+    let urlWithQueryParameters = URL(string: "www.test.com")!
+    let resource = MockCustomNetworkResource(url: urlWithQueryParameters)
+
+    let urlRequest = resource.urlRequest()
+    XCTAssertEqual(urlRequest?.url?.absoluteString, "www.test.com")
+  }
+
   func test_urlRequest_resourceURLWithQueryParametersAndQueryItems() {
     let mockedURLQueryItems = [URLQueryItem(name: "query-name-a", value: "query-value-a")]
     let resource = MockCustomNetworkResource(url: urlWithQueryItem, queryItems: mockedURLQueryItems)


### PR DESCRIPTION
Currently when making a request with no `URLQueryItems`, a `?` is added to the network request. This is due to the fact we're setting an empty array of `URLQueryItems`, rather than `nil`. 

This changes the behaviour to only set the array if we have `URLQueryItem`s.