### PR TITLE
Allow cancellation of all requests associated with a URLSessionType instance

### DIFF
--- a/Sources/TABResourceLoader/Services/URLSessionType.swift
+++ b/Sources/TABResourceLoader/Services/URLSessionType.swift
@@ -42,23 +42,13 @@ extension URLSession: URLSessionType {
   }
   
   public func cancelAllRequests() {
-    guard #available(iOS 9.0, *) else {
-      cancelRequestsByType()
-      return
-    }
-    
-    getAllTasks { (tasks) in
-     URLSession.cancelTasks(tasks) }
-  }
-  
-  private func cancelRequestsByType() {
     getTasksWithCompletionHandler { (dataTasks, uploadTasks, downloadTasks) in
       URLSession.cancelTasks(dataTasks)
       URLSession.cancelTasks(uploadTasks)
       URLSession.cancelTasks(downloadTasks)
     }
   }
-  
+
   private static func cancelTasks(_ tasks: [URLSessionTask]) {
      tasks.forEach { $0.cancel() }
   }

--- a/Sources/TABResourceLoader/Services/URLSessionType.swift
+++ b/Sources/TABResourceLoader/Services/URLSessionType.swift
@@ -31,6 +31,7 @@ import Foundation
 public protocol URLSessionType {
   func perform(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
   func invalidateAndCancel()
+  func cancelAllRequests()
 }
 
 extension URLSession: URLSessionType {
@@ -38,6 +39,28 @@ extension URLSession: URLSessionType {
     let task = dataTask(with: request, completionHandler: completion)
     task.resume()
     return task
+  }
+  
+  public func cancelAllRequests() {
+    guard #available(iOS 9.0, *) else {
+      cancelRequestsByType()
+      return
+    }
+    
+    getAllTasks { (tasks) in
+     URLSession.cancelTasks(tasks) }
+  }
+  
+  private func cancelRequestsByType() {
+    getTasksWithCompletionHandler { (dataTasks, uploadTasks, downloadTasks) in
+      URLSession.cancelTasks(dataTasks)
+      URLSession.cancelTasks(uploadTasks)
+      URLSession.cancelTasks(downloadTasks)
+    }
+  }
+  
+  private static func cancelTasks(_ tasks: [URLSessionTask]) {
+     tasks.forEach { $0.cancel() }
   }
 }
 

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '7.0.1'
+  spec.version      = '7.1.0'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'

--- a/TABResourceLoader.xcodeproj/project.pbxproj
+++ b/TABResourceLoader.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		4FF005351DC9F9E0006BBACE /* NetworkJSONArrayResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF005341DC9F9E0006BBACE /* NetworkJSONArrayResourceType.swift */; };
 		4FF581761F051F8F008D0A20 /* Result+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF581741F051F23008D0A20 /* Result+Additions.swift */; };
 		4FFA60A51D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFA60A41D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift */; };
+		5F26A0A21FED1F6A0075BDFD /* URLSession+URLSessionTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F26A0A11FED1F6A0075BDFD /* URLSession+URLSessionTypeTests.swift */; };
 		EA00EEB11F8D286900166ABA /* NetworkJSONDecodableResourceTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00EEAF1F8D27D900166ABA /* NetworkJSONDecodableResourceTypeTests.swift */; };
 		EA00EEB31F8D293C00166ABA /* NetworkPropertyListDecodableResourceTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00EEB21F8D293C00166ABA /* NetworkPropertyListDecodableResourceTypeTests.swift */; };
 		EA1EE0C81F87DD8500902527 /* JSONDecodableResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1EE0C71F87DD8500902527 /* JSONDecodableResourceType.swift */; };
@@ -165,6 +166,7 @@
 		4FF005341DC9F9E0006BBACE /* NetworkJSONArrayResourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkJSONArrayResourceType.swift; sourceTree = "<group>"; };
 		4FF581741F051F23008D0A20 /* Result+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+Additions.swift"; sourceTree = "<group>"; };
 		4FFA60A41D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkJSONDictionaryResourceType.swift; sourceTree = "<group>"; };
+		5F26A0A11FED1F6A0075BDFD /* URLSession+URLSessionTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+URLSessionTypeTests.swift"; sourceTree = "<group>"; };
 		EA00EEAF1F8D27D900166ABA /* NetworkJSONDecodableResourceTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkJSONDecodableResourceTypeTests.swift; sourceTree = "<group>"; };
 		EA00EEB21F8D293C00166ABA /* NetworkPropertyListDecodableResourceTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPropertyListDecodableResourceTypeTests.swift; sourceTree = "<group>"; };
 		EA1EE0C71F87DD8500902527 /* JSONDecodableResourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodableResourceType.swift; sourceTree = "<group>"; };
@@ -406,6 +408,7 @@
 				4F079D521D84599300D08DA0 /* NetworkDataResourceServiceTests.swift */,
 				4F079D531D84599300D08DA0 /* SubclassedNetworkDataResourceServiceTests.swift */,
 				4F4BE5291ECB40AC00C2CC56 /* NetworkResponseHandlerTests.swift */,
+				5F26A0A11FED1F6A0075BDFD /* URLSession+URLSessionTypeTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -739,6 +742,7 @@
 				4F079D7B1D846DD400D08DA0 /* SubclassedNetworkDataResourceServiceTests.swift in Sources */,
 				4F079D6F1D8459D400D08DA0 /* ResourceOperationTests.swift in Sources */,
 				EA1EE0D31F881BCC00902527 /* MockJSONDecodableResource.swift in Sources */,
+				5F26A0A21FED1F6A0075BDFD /* URLSession+URLSessionTypeTests.swift in Sources */,
 				EA1EE0D61F881CFB00902527 /* String+Additions.swift in Sources */,
 				EA1EE0E11F882F3B00902527 /* PropertyListDecodableResourceTypeTests.swift in Sources */,
 				4F079D701D8459D400D08DA0 /* ImageResourceTypeTests.swift in Sources */,

--- a/Tests/TABResourceLoaderTests/Mocks/MockResourceService.swift
+++ b/Tests/TABResourceLoaderTests/Mocks/MockResourceService.swift
@@ -10,10 +10,12 @@ import Foundation
 @testable import TABResourceLoader
 
 class MockSessionThatDoesNothing: URLSessionType {
+  
   public func perform(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
     return URLSessionDataTask()
   }
   func invalidateAndCancel() { /* not implemented */ }
+  func cancelAllRequests() { /* not implemented */ }
 }
 
 class MockResourceService: ResourceServiceType {

--- a/Tests/TABResourceLoaderTests/Mocks/MockURLSession.swift
+++ b/Tests/TABResourceLoaderTests/Mocks/MockURLSession.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import TABResourceLoader
 
 final class MockURLSession: URLSessionType {
-
+  
   typealias URLSessionCompletionHandler = (Data?, URLResponse?, Error?) -> Void
 
   var capturedRequest: URLRequest?
@@ -26,4 +26,6 @@ final class MockURLSession: URLSessionType {
   func invalidateAndCancel() {
     invalidateAndCancelCallCount += 1
   }
+  
+ func cancelAllRequests() { /* not implemented */ }
 }

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkDataResourceServiceURLSessionTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkDataResourceServiceURLSessionTests.swift
@@ -15,6 +15,7 @@ class MockSessionToTestExposed: URLSessionType {
     return URLSessionDataTask()
   }
   func invalidateAndCancel() { /* not implemented */ }
+  func cancelAllRequests() { /* not implemented */ }
 }
 
 class NetworkDataResourceServiceURLSessionTests: XCTestCase { //swiftlint:disable:this type_name

--- a/Tests/TABResourceLoaderTests/Services/URLSession+URLSessionTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/URLSession+URLSessionTypeTests.swift
@@ -1,0 +1,34 @@
+//
+//  URLSession+URLSessionTypeTests.swift
+//  TABResourceLoaderTests
+//
+//  Created by Priya Marwaha on 22/12/17.
+//  Copyright © 2017 Luciano Marisi. All rights reserved.
+//
+
+import XCTest
+import TABResourceLoader
+
+class URLSessionTests: XCTestCase {
+    
+  func testCancelAllRequests() {
+    let config = URLSessionConfiguration.default
+    let urlSession = URLSession(configuration: config)
+    let url = URL(string: "https://www.test.com")!
+    let wait = expectation(description: "URLSession cancels request")
+    let dataTask = urlSession.dataTask(with: url) { (data, response, error) in
+      guard let error = error else {
+        XCTFail("Did not receive expected cancellation error")
+        return
+      }
+      if error._code == NSURLErrorCancelled && error._domain == NSURLErrorDomain {
+      	wait.fulfill()
+      }
+    }
+    dataTask.resume()
+   	urlSession.cancelAllRequests()
+  
+    waitForExpectations(timeout: 1)
+  }
+    
+}

--- a/Tests/TABResourceLoaderTests/Services/URLSession+URLSessionTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/URLSession+URLSessionTypeTests.swift
@@ -26,9 +26,7 @@ class URLSessionTests: XCTestCase {
       }
     }
     dataTask.resume()
-   	urlSession.cancelAllRequests()
-  
+    urlSession.cancelAllRequests()
     waitForExpectations(timeout: 1)
   }
-    
 }


### PR DESCRIPTION
While using the `NetworkDataResourceService`, I'd like to be able to cancel all requests associated with the `URLSessionType` instance provided to it in one go, instead of just using the `Cancellable` instances returned by the service's `fetch` method.

_Note_
I have't updated the pod spec version yet - wasn't sure if  you'd like it to move to 7.0.2 or (ideally) 7.1.0. Let me know