### PR TITLE
Added cancelAllRequests method on resource service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
-## 7.1.0
+## 7.2.0
 
 - Adds the ability to cancel all requests from the resource service.
+
+## 7.1.0
+
+- Adds the ability to cancel all requests from the URLSessionType.
 
 ## 7.0.1
 

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -109,7 +109,7 @@ open class NetworkDataResourceService {
   /**
    Cancels all requests associated with this service's session
    */
-  func cancelAllRequests() {
+  open func cancelAllRequests() {
     session.cancelAllRequests()
   }
 

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -105,5 +105,12 @@ open class NetworkDataResourceService {
     }
     return cancellable
   }
+  
+  /**
+   Cancels all requests associated with this service's session
+   */
+  func cancelAllRequests() {
+    session.cancelAllRequests()
+  }
 
 }

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '7.1.0'
+  spec.version      = '7.2.0'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -16,7 +16,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
   var mockSession: MockURLSession!
   var mockResource: MockDefaultNetworkDataResource!
   var mockNetworkServiceActivity: MockNetworkServiceActivity!
-  let mockURL = URL(string: "http://test.com")!
+  let mockURL = URL(string: "https://test.com")!
 
   var testService: GenericNetworkDataResourceService<MockDefaultNetworkDataResource>!
 
@@ -224,5 +224,21 @@ class NetworkDataResourceServiceTests: XCTestCase {
     }
     waitForExpectation()
   }
-
+  
+  func testCancelAllRequests() {
+    testService = GenericNetworkDataResourceService<MockDefaultNetworkDataResource>()
+    performAsyncTest { expectation in
+      testService.fetch(resource: mockResource) { result in
+        switch result {
+        case .failure(.sessionError(let error), _):
+          if error._code == NSURLErrorCancelled && error._domain == NSURLErrorDomain {
+            expectation?.fulfill()
+          }
+        default:
+          XCTFail("No error found")
+        }
+      }
+      testService.cancelAllRequests()
+    }
+  }
 }


### PR DESCRIPTION
The `session` instance of the service is internal, so the only way to cancel all requests was to hold on to the instance of  the `URLSessionType` provided to it. I've now added a `cancelAllRequests` method to the resource service itself, so we can directly call this.