### PR TITLE
Resource-specific properties set by resource service subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 8.0.0
+
+- Adding a `resource` argument to the "additional" functions of the resource service - the functions that are intended to be overridden by subclasses.
+
+Providing the subclass with the resource gives that subclass an opportunity to set parameters of the URL request based on the resource. This is different to the resource providing those parameters itself, e.g. the resource could implement the `httpHeaderFields` and `queryItems` properties.
+
+Consider a subclass that adds the requirement that its resources must conform to a protocol `GraphQLResouce`. The `GraphQLResouce` protocol requires a property `queryName: String` to be implemented by its conformers.
+
+The `NetworkDataResourceService` can now add in the `queryName` to either the HTTP header fields or the URL query items. It would be unreliable to expect all resources to implement the `queryItems` and `httpHeaderFields` to add the `queryName` key/value.
+
+> _**NOTE:** This only impacts consumers that subclass `NetworkDataResourceService` and override the `additionalHeaderFields` implementation._
+
+API-Breaking Change: This release modifies the `NetworkDataResourceService.additionalHeaderFields` function by adding an argument to the function.
+
 ## 7.2.0
 
 - Adds the ability to cancel all requests from the resource service.

--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -62,9 +62,11 @@ public protocol NetworkResourceType {
   /**
    Convenience function that builds a URLRequest for this resource
 
+   - parameter additionalQueryParameters: Query parameters to be added to the URL
    - returns: A URLRequest or nil if the construction of the request failed
    */
-  func urlRequest() -> URLRequest?
+  
+  func urlRequest(with: [URLQueryItem]) -> URLRequest?
 }
 
 // MARK: - NetworkJSONResource defaults
@@ -75,10 +77,10 @@ public extension NetworkResourceType {
   public var jsonBody: Any? { return nil }
   public var queryItems: [URLQueryItem]? { return nil }
 
-  public func urlRequest() -> URLRequest? {
+  public func urlRequest(with additionalQueryParameters: [URLQueryItem]) -> URLRequest? {
     var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
     let initialItems = urlComponents?.queryItems
-    urlComponents?.queryItems = allQueryItems(initialItems: initialItems)
+    urlComponents?.queryItems = allQueryItems(initialItems: initialItems, additional: additionalQueryParameters)
 
     guard let urlFromComponents = urlComponents?.url else { return nil }
 
@@ -93,10 +95,9 @@ public extension NetworkResourceType {
     return request
   }
 
-  private func allQueryItems(initialItems: [URLQueryItem]?) -> [URLQueryItem]? {
-    let combinedQueryItems = (initialItems ?? []) + (queryItems ?? [])
-    let allQueryItems = combinedQueryItems.isEmpty ? nil : combinedQueryItems
-    return allQueryItems
+  private func allQueryItems(initialItems: [URLQueryItem]?, additional: [URLQueryItem]) -> [URLQueryItem]? {
+    let combinedQueryItems = (initialItems ?? []) + (queryItems ?? []) + additional
+    return combinedQueryItems.isEmpty ? nil : combinedQueryItems
   }
 }
 

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '7.2.0'
+  spec.version      = '8.0.0'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'

--- a/Tests/TABResourceLoaderTests/Mocks/MockNilURLRequestNetworkJSONResource.swift
+++ b/Tests/TABResourceLoaderTests/Mocks/MockNilURLRequestNetworkJSONResource.swift
@@ -13,7 +13,7 @@ struct MockNilURLRequestNetworkJSONResource: NetworkDataResourceType {
   typealias Model = String
   let url: URL = URL(string: "www.test.com")!
 
-  func urlRequest() -> URLRequest? {
+  func urlRequest(with: [URLQueryItem]) -> URLRequest? {
     return nil
   }
 

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -52,7 +52,7 @@ class NetworkResourceTypeTests: XCTestCase {
     let expectedURL = "\(url)?query-name=query-value"
     let mockNetworkResource = MockCustomNetworkResource(url: url, httpRequestMethod: expectedHTTPMethod, httpHeaderFields: expectedAllHTTPHeaderFields, jsonBody: expectedJSONBody, queryItems: mockedURLQueryItems)
 
-    let urlRequest = mockNetworkResource.urlRequest()
+    let urlRequest = mockNetworkResource.urlRequest(with: [])
     XCTAssertNotNil(urlRequest)
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURL)
     XCTAssertEqual(urlRequest?.httpMethod, expectedHTTPMethod.rawValue)
@@ -65,7 +65,7 @@ class NetworkResourceTypeTests: XCTestCase {
     let urlWithQueryParameters = URL(string: "www.test.com?query-name=query-value")!
     let resource = MockCustomNetworkResource(url: urlWithQueryParameters)
 
-    let urlRequest = resource.urlRequest()
+    let urlRequest = resource.urlRequest(with: [])
     XCTAssertEqual(urlRequest?.url?.absoluteString, urlWithQueryParameters.absoluteString)
   }
 
@@ -73,7 +73,7 @@ class NetworkResourceTypeTests: XCTestCase {
     let urlWithQueryParameters = URL(string: "www.test.com")!
     let resource = MockCustomNetworkResource(url: urlWithQueryParameters)
 
-    let urlRequest = resource.urlRequest()
+    let urlRequest = resource.urlRequest(with: [])
     XCTAssertEqual(urlRequest?.url?.absoluteString, "www.test.com")
   }
 
@@ -82,7 +82,7 @@ class NetworkResourceTypeTests: XCTestCase {
     let resource = MockCustomNetworkResource(url: urlWithQueryItem, queryItems: mockedURLQueryItems)
 
     let expectedURLString = "\(urlWithQueryItem)&query-name-a=query-value-a"
-    let urlRequest = resource.urlRequest()
+    let urlRequest = resource.urlRequest(with: [])
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)
   }
 
@@ -91,7 +91,7 @@ class NetworkResourceTypeTests: XCTestCase {
     let resource = MockCustomNetworkResource(url: urlWithQueryItem, queryItems: mockedURLQueryItems)
 
     let expectedURLString = "\(urlWithQueryItem)&query-name=query-value-a"
-    let urlRequest = resource.urlRequest()
+    let urlRequest = resource.urlRequest(with: [])
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)
   }
 

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -45,7 +45,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
   func test_fetch_callsPerformRequestOnSessionWithCorrectURLRequest() {
     testService.fetch(resource: mockResource) { _ in }
     let capturedRequest = mockSession.capturedRequest
-    let expectedRequest = mockResource.urlRequest()
+    let expectedRequest = mockResource.urlRequest(with: [])
     XCTAssertNotNil(expectedRequest?.allHTTPHeaderFields)
     XCTAssertEqual(capturedRequest, expectedRequest)
   }
@@ -71,7 +71,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
   func test_fetch_withInvalidURLRequest_callsFailureWithCorrectError() {
     let mockInvalidURLResource = MockNilURLRequestNetworkJSONResource()
     let newTestRequestManager = GenericNetworkDataResourceService<MockNilURLRequestNetworkJSONResource>(session: mockSession)
-    XCTAssertNil(mockInvalidURLResource.urlRequest())
+    XCTAssertNil(mockInvalidURLResource.urlRequest(with: []))
     performAsyncTest { expectation in
       newTestRequestManager.fetch(resource: mockInvalidURLResource) { result in
         switch result {


### PR DESCRIPTION
## 🛠 Description & Reasoning

Adding a `resource` argument to the "additional" functions of the resource service - the functions that are intended to be overridden by subclasses.

Providing the subclass with the resource gives that subclass an opportunity to set parameters of the URL request based on the resource. This is different to the resource providing those parameters itself, e.g. the resource could implement the `httpHeaderFields` and `queryItems` properties.

Consider a subclass that adds the requirement that its resources must conform to a protocol `GraphQLResouce`. The `GraphQLResouce` protocol requires a property `queryName: String` to be implemented by its conformers.

The `NetworkDataResourceService` can now add in the `queryName` to either the HTTP header fields or the URL query items. It would be unreliable to expect all resources to implement the `queryItems` and `httpHeaderFields` to add the `queryName` key/value.

> _**NOTE:** This only impacts consumers that subclass `NetworkDataResourceService` and override the `additionalHeaderFields` implementation._

## ⚠️ API-Breaking Changes

This PR modifies the `NetworkDataResourceService.additionalHeaderFields` function by adding an argument to the function. This function is overridden (not invoked explicitly), which is why we cannot provide a default argument value. For this reason, this is an API-breaking change.

## ✨ Other Changes

The addition of the `NetworkDataResourceService.additionalQueryParameters` function. This serves the same purpose as the `additionalHeaderFields` function, but for URL query parameters.