### PR TITLE
 Add optional  requestTimeInterval  property to NetworkResourceType to set a URLRequest specific timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 7.2.2
+
+- Adds  optional  `requestTimeInterval`  property to `NetworkResourceType` which can be used to set a `URLRequest` specific timeout for the resource.
+
 ## 7.2.1
 
 - Fixes an issue where `super.start()` was being called unnecessarily.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.2.2
 
-- Adds  optional  `requestTimeInterval`  property to `NetworkResourceType` which can be used to set a `URLRequest` specific timeout for the resource.
+- Adds  optional  `requestTimeoutInterval`  property to `NetworkResourceType` which can be used to set a `URLRequest` specific timeout for the resource.
 
 ## 7.2.1
 

--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -60,7 +60,7 @@ public protocol NetworkResourceType {
   var queryItems: [URLQueryItem]? { get }
   
   /// The time interval for the URLRequest for this resource
-  var requestTimeInterval: TimeInterval? { get }
+  var requestTimeoutInterval: TimeInterval? { get }
 
   /**
    Convenience function that builds a URLRequest for this resource
@@ -77,7 +77,7 @@ public extension NetworkResourceType {
   public var httpHeaderFields: [String: String]? { return [:] }
   public var jsonBody: Any? { return nil }
   public var queryItems: [URLQueryItem]? { return nil }
-  public var requestTimeInterval: TimeInterval? { return nil }
+  public var requestTimeoutInterval: TimeInterval? { return nil }
 
   public func urlRequest() -> URLRequest? {
     var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
@@ -86,7 +86,7 @@ public extension NetworkResourceType {
 
     guard let urlFromComponents = urlComponents?.url else { return nil }
     var request: URLRequest
-    if let timeoutInterval = requestTimeInterval {
+    if let timeoutInterval = requestTimeoutInterval {
       request = URLRequest(url: urlFromComponents, timeoutInterval: timeoutInterval)
     } else {
       request = URLRequest(url: urlFromComponents)

--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -58,6 +58,9 @@ public protocol NetworkResourceType {
 
   /// The query items to be added to the url to fetch this resource
   var queryItems: [URLQueryItem]? { get }
+  
+  /// The time interval for the URLRequest for this resource
+  var requestTimeInterval: TimeInterval? { get }
 
   /**
    Convenience function that builds a URLRequest for this resource
@@ -74,6 +77,7 @@ public extension NetworkResourceType {
   public var httpHeaderFields: [String: String]? { return [:] }
   public var jsonBody: Any? { return nil }
   public var queryItems: [URLQueryItem]? { return nil }
+  public var requestTimeInterval: TimeInterval? { return nil }
 
   public func urlRequest() -> URLRequest? {
     var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
@@ -81,8 +85,12 @@ public extension NetworkResourceType {
     urlComponents?.queryItems = allQueryItems(initialItems: initialItems)
 
     guard let urlFromComponents = urlComponents?.url else { return nil }
-
-    var request = URLRequest(url: urlFromComponents)
+    var request: URLRequest
+    if let timeoutInterval = requestTimeInterval {
+      request = URLRequest(url: urlFromComponents, timeoutInterval: timeoutInterval)
+    } else {
+      request = URLRequest(url: urlFromComponents)
+    }
     request.allHTTPHeaderFields = httpHeaderFields
     request.httpMethod = httpRequestMethod.rawValue
 

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '7.2.1'
+  spec.version      = '7.2.2'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -21,6 +21,7 @@ private struct MockCustomNetworkResource: NetworkResourceType {
   let httpHeaderFields: [String: String]?
   let jsonBody: Any?
   let queryItems: [URLQueryItem]?
+  let requestTimeInterval: TimeInterval? = 27
 
   init(url: URL, httpRequestMethod: HTTPMethod = .get, httpHeaderFields: [String : String]? = nil, jsonBody: Any? = nil, queryItems: [URLQueryItem]? = nil) {
     self.url = url
@@ -35,13 +36,21 @@ class NetworkResourceTypeTests: XCTestCase {
 
   let url = URL(string: "www.test.com")!
   let urlWithQueryItem = URL(string: "www.test.com?query-name=query-value")!
+  // using the defaut time interval dynamically instead of hard-coding a value that may change at
+  // some point of time
+  private lazy var defaultRequestTimeOut: TimeInterval = {
+    let request = URLRequest(url: url)
+    return request.timeoutInterval
+  }()
 
   func test_correctDefaultValues() {
     let resource = MockDefaultNetworkResource(url: url)
+    let request = resource.urlRequest()
     XCTAssertEqual(resource.httpRequestMethod, HTTPMethod.get)
     XCTAssertEqual(resource.httpHeaderFields!, [:])
     XCTAssertNil(resource.jsonBody)
     XCTAssertNil(resource.queryItems)
+   	XCTAssertEqual(request?.timeoutInterval, defaultRequestTimeOut)
   }
 
   func test_urlRequest_allProperties() {
@@ -59,6 +68,7 @@ class NetworkResourceTypeTests: XCTestCase {
     XCTAssertEqual(urlRequest!.allHTTPHeaderFields!, expectedAllHTTPHeaderFields)
     let expectedJSONData = try? JSONSerialization.data(withJSONObject: expectedJSONBody, options: JSONSerialization.WritingOptions.prettyPrinted)
     XCTAssertEqual(urlRequest!.httpBody, expectedJSONData)
+    XCTAssertEqual(urlRequest?.timeoutInterval, 27)
   }
 
   func test_urlRequest_resourceURLWithQueryParameters() {

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -21,7 +21,7 @@ private struct MockCustomNetworkResource: NetworkResourceType {
   let httpHeaderFields: [String: String]?
   let jsonBody: Any?
   let queryItems: [URLQueryItem]?
-  let requestTimeInterval: TimeInterval? = 27
+  let requestTimeoutInterval: TimeInterval? = 27
 
   init(url: URL, httpRequestMethod: HTTPMethod = .get, httpHeaderFields: [String : String]? = nil, jsonBody: Any? = nil, queryItems: [URLQueryItem]? = nil) {
     self.url = url

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -50,7 +50,7 @@ class NetworkResourceTypeTests: XCTestCase {
     XCTAssertEqual(resource.httpHeaderFields!, [:])
     XCTAssertNil(resource.jsonBody)
     XCTAssertNil(resource.queryItems)
-   	XCTAssertEqual(request?.timeoutInterval, defaultRequestTimeOut)
+    XCTAssertEqual(request?.timeoutInterval, defaultRequestTimeOut)
   }
 
   func test_urlRequest_allProperties() {


### PR DESCRIPTION
Currently, we can only set a timeout interval for the `URLSession`. With this PR, we get the ability to use a different timeout value for all requests for a specific `NetworkResourceType`