### PR TITLE
Add swift_version to podspec

### DIFF
--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'TABResourceLoader'
   spec.homepage     = 'https://github.com/theappbusiness/TABResourceLoader'
-  spec.version      = '8.0.0'
+  spec.version      = '8.0.1'
   spec.license      = { :type => 'MIT' }
   spec.authors      = { 'Luciano Marisi' => 'luciano@techbrewers.com' }
   spec.summary      = 'Framework for loading resources from a network service'

--- a/TABResourceLoader.podspec
+++ b/TABResourceLoader.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |spec|
   }
   spec.source_files = 'Sources/**/*.swift'
   spec.ios.deployment_target = '8.0'
+  spec.swift_version = '4.2'
 end


### PR DESCRIPTION
Cocoapods 1.6.0 (beta) requires `swift_version` to be defined in the `.podspec`. Otherwise, running `pod install` will result in an error:

```
[!] Unable to determine Swift version for the following pods:

- `TABResourceLoader` does not specify a Swift version and none of the targets (`<TARGET_NAME>`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```

This PR updates the podspec with the `swift_version` parameter. This is backwards compatible with Cocoapods >= 1.4.0, so this change won't cause any issues if you're not on the 1.6.0 beta. The use of `.swift-version` file has been deprecated some time ago (Cocoapods no longer fully respects it), so it makes sense to migrate to `swift_version`.

Discussion: https://github.com/CocoaPods/CocoaPods/issues/7770
PR for the change: https://github.com/CocoaPods/CocoaPods/pull/7777