### PR TITLE
Query URL Allowed Character Set

### DIFF
--- a/Example/Models/Failure model example/RegistrationResource.swift
+++ b/Example/Models/Failure model example/RegistrationResource.swift
@@ -52,7 +52,7 @@ struct RegistrationResource: NetworkJSONDictionaryResourceType {
   }
 
   // MARK: JSONDictionaryResourceType
-  func model(from jsonDictionary: [String : Any]) throws -> Model {
+  func model(from jsonDictionary: [String: Any]) throws -> Model {
     if let error = jsonDictionary["errorCode"] as? String {
         let error = try RegistrationErrorType(error: error)
         return .failure(type: error)

--- a/Example/Models/Multiple responses example/CitiesResponse.swift
+++ b/Example/Models/Multiple responses example/CitiesResponse.swift
@@ -19,7 +19,7 @@ enum CitiesResponse {
 }
 
 extension CitiesResponse {
-  public init(jsonDictionary: [String : Any]) throws {
+  public init(jsonDictionary: [String: Any]) throws {
     if let citiesJSONArray = jsonDictionary["cities"] as? [[String: Any]] {
       self = .cities(citiesJSONArray.compactMap(City.init))
     } else if let city = City(jsonDictionary: jsonDictionary) {

--- a/Example/Models/Multiple responses example/MultipleResponseResource.swift
+++ b/Example/Models/Multiple responses example/MultipleResponseResource.swift
@@ -21,7 +21,7 @@ struct MultipleResponseResource: NetworkJSONDictionaryResourceType {
   }
 
   // MARK: JSONDictionaryResourceType
-  func model(from jsonDictionary: [String : Any]) throws -> Model {
+  func model(from jsonDictionary: [String: Any]) throws -> Model {
     return try CitiesResponse(jsonDictionary: jsonDictionary)
   }
 

--- a/Example/Models/Multiple responses example/ServerError.swift
+++ b/Example/Models/Multiple responses example/ServerError.swift
@@ -13,7 +13,7 @@ struct ServerError {
 }
 
 extension ServerError {
-  init?(jsonDictionary: [String : Any]) {
+  init?(jsonDictionary: [String: Any]) {
     guard let parsedErrorMessage = jsonDictionary["errorMessage"] as? String else {
       return nil
     }

--- a/Example/Models/Simple example/CitiesResource.swift
+++ b/Example/Models/Simple example/CitiesResource.swift
@@ -25,7 +25,7 @@ struct CitiesResource: NetworkJSONDictionaryResourceType {
   }
 
   // MARK: JSONDictionaryResourceType
-  func model(from jsonDictionary: [String : Any]) throws -> Model {
+  func model(from jsonDictionary: [String: Any]) throws -> Model {
     guard let
       citiesJSONArray = jsonDictionary["cities"] as? [[String: Any]]
       else {

--- a/Example/Models/Simple example/City.swift
+++ b/Example/Models/Simple example/City.swift
@@ -13,7 +13,7 @@ struct City {
 }
 
 extension City {
-  init?(jsonDictionary: [String : Any]) {
+  init?(jsonDictionary: [String: Any]) {
     guard let parsedName = jsonDictionary["name"] as? String else {
       return nil
     }

--- a/Sources/TABResourceLoader/Protocols/Resource types/JSONDictionaryResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/JSONDictionaryResourceType.swift
@@ -39,7 +39,7 @@ public protocol JSONDictionaryResourceType: DataResourceType {
 
    - returns: An instantiated model if parsing was successful, otherwise throws
    */
-  func model(from jsonDictionary: [String : Any]) throws -> Model
+  func model(from jsonDictionary: [String: Any]) throws -> Model
 
   /**
    Optionally returns an error from the JSON dictionary provided
@@ -48,7 +48,7 @@ public protocol JSONDictionaryResourceType: DataResourceType {
    
    - returns: An error from the jsonDictionary
    */
-  func error(from jsonDictionary: [String : Any]) -> Error?
+  func error(from jsonDictionary: [String: Any]) -> Error?
 }
 
 extension JSONDictionaryResourceType {
@@ -65,7 +65,7 @@ extension JSONDictionaryResourceType {
     return error(from: jsonDictionary)
   }
 
-  public func jsonDictionary(from data: Data) throws ->  [String : Any] {
+  public func jsonDictionary(from data: Data) throws ->  [String: Any] {
     guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) else {
       throw JSONParsingError.invalidJSONData
     }
@@ -81,7 +81,7 @@ extension JSONDictionaryResourceType {
 
 // No errors are returned by default
 public extension JSONDictionaryResourceType {
-  func error(from jsonDictionary: [String : Any]) -> Error? {
+  func error(from jsonDictionary: [String: Any]) -> Error? {
     return nil
   }
 }

--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -113,7 +113,7 @@ public extension NetworkResourceType {
       return urlComponents
     }
     
-    let encodedQueryStrings = createStringsArrayOf(queryItems)
+    let encodedQueryStrings = createQueryItemStrings(queryItems)
     
     let encodedQuery = encodedQueryStrings.joined(separator: "&")
     
@@ -130,7 +130,7 @@ public extension NetworkResourceType {
     return urlComponents
   }
   
-  private func createStringsArrayOf(_ queryItems: [URLQueryItem]) -> [String] {
+  private func createQueryItemStrings(_ queryItems: [URLQueryItem]) -> [String] {
     let queryItemStrings = queryItems.compactMap { item -> String? in
       let parameter = item.name.addingPercentEncoding(withAllowedCharacters: urlQueryAllowedCharacterSet) ?? ""
       

--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -97,11 +97,8 @@ public extension NetworkResourceType {
     }
 
     var request: URLRequest
-    if let timeoutInterval = requestTimeoutInterval {
-      request = URLRequest(url: urlFromComponents, timeoutInterval: timeoutInterval)
-    } else {
-      request = URLRequest(url: urlFromComponents)
-    }
+
+    request = URLRequest(url: urlFromComponents, timeoutInterval: requestTimeoutInterval ?? URLSessionConfiguration.default.timeoutIntervalForRequest)
     request.allHTTPHeaderFields = httpHeaderFields
     request.httpMethod = httpRequestMethod.rawValue
 
@@ -122,11 +119,9 @@ public extension NetworkResourceType {
     }
 
     let encodedQueryStrings = queryItems.compactMap { (item) -> String? in
-
       let parameter = item.name.addingPercentEncoding(withAllowedCharacters: urlQueryAllowedCharacterSet) ?? ""
+      guard !parameter.isEmpty else { return nil }
       let value = item.value?.addingPercentEncoding(withAllowedCharacters: urlQueryAllowedCharacterSet) ?? ""
-
-      guard !parameter.isEmpty, !value.isEmpty else { return nil }
 
       return "\(parameter)=\(value)"
     }

--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -88,7 +88,7 @@ public extension NetworkResourceType {
 
   // MARK: Public functions
 
-  func urlRequest() -> URLRequest? {
+  public func urlRequest() -> URLRequest? {
     guard let urlComponents = createURLComponents(), let urlFromComponents = urlComponents.url else {
       return nil
     }
@@ -113,7 +113,7 @@ public extension NetworkResourceType {
       return urlComponents
     }
 
-    let encodedQueryStrings = queryItems.compactMap { (item) -> String? in
+    let encodedQueryStrings = queryItems.compactMap { item -> String? in
       let parameter = item.name.addingPercentEncoding(withAllowedCharacters: urlQueryAllowedCharacterSet) ?? ""
 
       guard !parameter.isEmpty else {

--- a/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
+++ b/Sources/TABResourceLoader/Protocols/Resource types/NetworkResourceType.swift
@@ -36,7 +36,7 @@ public enum HTTPMethod: String {
   case delete
   case head
   case put
-
+  
   public var rawValue: String {
     return "\(self)".uppercased()
   }
@@ -46,26 +46,26 @@ public enum HTTPMethod: String {
 public protocol NetworkResourceType {
   /// The URL of the resource
   var url: URL { get }
-
+  
   /// The HTTP method used to fetch this resource
   var httpRequestMethod: HTTPMethod { get }
-
+  
   /// The HTTP header fields used to fetch this resource
   var httpHeaderFields: [String: String]? { get }
-
+  
   /// The HTTP body as JSON used to fetch this resource
   var jsonBody: Any? { get }
-
+  
   /// The query items to be added to the url to fetch this resource
   var queryItems: [URLQueryItem]? { get }
-
+  
   /// The time interval for the URLRequest for this resource
   var requestTimeoutInterval: TimeInterval? { get }
-
+  
   /// The CharacterSet of allowed characters for encoding the query parameters.
   /// By default, this will be `CharacterSet.improvedUrlQueryAllowed`.
   var urlQueryAllowedCharacterSet: CharacterSet { get }
-
+  
   /**
    Convenience function that builds a URLRequest for this resource
    
@@ -76,68 +76,73 @@ public protocol NetworkResourceType {
 
 // MARK: - NetworkJSONResource defaults
 public extension NetworkResourceType {
-
+  
   // MARK: Public properties
-
+  
   public var httpRequestMethod: HTTPMethod { return .get }
   public var httpHeaderFields: [String: String]? { return [:] }
   public var jsonBody: Any? { return nil }
   public var queryItems: [URLQueryItem]? { return nil }
   public var requestTimeoutInterval: TimeInterval? { return nil }
   public var urlQueryAllowedCharacterSet: CharacterSet { return .improvedUrlQueryAllowed }
-
+  
   // MARK: Public functions
-
+  
   public func urlRequest() -> URLRequest? {
     guard let urlComponents = createURLComponents(), let urlFromComponents = urlComponents.url else {
       return nil
     }
-
+    
     var request = URLRequest(url: urlFromComponents, timeoutInterval: requestTimeoutInterval ?? URLSessionConfiguration.default.timeoutIntervalForRequest)
     request.allHTTPHeaderFields = httpHeaderFields
     request.httpMethod = httpRequestMethod.rawValue
-
+    
     if let body = jsonBody {
       request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: .prettyPrinted)
     }
-
+    
     return request
   }
-
+  
   // MARK: Private helpers
-
+  
   private func createURLComponents() -> URLComponents? {
     guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return nil }
-
+    
     guard let queryItems = queryItems else {
       return urlComponents
     }
-
-    let encodedQueryStrings = queryItems.compactMap { item -> String? in
-      let parameter = item.name.addingPercentEncoding(withAllowedCharacters: urlQueryAllowedCharacterSet) ?? ""
-
-      guard !parameter.isEmpty else {
-        return nil
-      }
-
-      let value = item.value?.addingPercentEncoding(withAllowedCharacters: urlQueryAllowedCharacterSet) ?? ""
-
-      return "\(parameter)=\(value)"
-    }
-
+    
+    let encodedQueryStrings = createStringsArrayOf(queryItems)
+    
     let encodedQuery = encodedQueryStrings.joined(separator: "&")
-
+    
     guard !encodedQuery.isEmpty else {
       return nil
     }
-
+    
     guard (urlComponents.percentEncodedQuery ?? "").isEmpty else {
       urlComponents.percentEncodedQuery?.append("&\(encodedQuery)")
       return urlComponents
     }
-
+    
     urlComponents.percentEncodedQuery = encodedQuery
     return urlComponents
+  }
+  
+  private func createStringsArrayOf(_ queryItems: [URLQueryItem]) -> [String] {
+    let queryItemStrings = queryItems.compactMap { item -> String? in
+      let parameter = item.name.addingPercentEncoding(withAllowedCharacters: urlQueryAllowedCharacterSet) ?? ""
+      
+      guard !parameter.isEmpty else {
+        return nil
+      }
+      
+      let value = item.value?.addingPercentEncoding(withAllowedCharacters: urlQueryAllowedCharacterSet) ?? ""
+      
+      return "\(parameter)=\(value)"
+    }
+    return queryItemStrings
   }
 }
 

--- a/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
+++ b/Sources/TABResourceLoader/Services/NetworkDataResourceService.swift
@@ -105,7 +105,7 @@ open class NetworkDataResourceService {
     }
     return cancellable
   }
-  
+
   /**
    Cancels all requests associated with this service's session
    */

--- a/Sources/TABResourceLoader/Services/URLSessionType.swift
+++ b/Sources/TABResourceLoader/Services/URLSessionType.swift
@@ -40,7 +40,7 @@ extension URLSession: URLSessionType {
     task.resume()
     return task
   }
-  
+
   public func cancelAllRequests() {
     getTasksWithCompletionHandler { (dataTasks, uploadTasks, downloadTasks) in
       URLSession.cancelTasks(dataTasks)

--- a/TABResourceLoader.xcodeproj/project.pbxproj
+++ b/TABResourceLoader.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		4FF581761F051F8F008D0A20 /* Result+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF581741F051F23008D0A20 /* Result+Additions.swift */; };
 		4FFA60A51D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFA60A41D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift */; };
 		5F26A0A21FED1F6A0075BDFD /* URLSession+URLSessionTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F26A0A11FED1F6A0075BDFD /* URLSession+URLSessionTypeTests.swift */; };
+		90B62B48223A5F6C00640CE9 /* CharacterSet+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B62B47223A5F6C00640CE9 /* CharacterSet+Additions.swift */; };
 		EA00EEB11F8D286900166ABA /* NetworkJSONDecodableResourceTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00EEAF1F8D27D900166ABA /* NetworkJSONDecodableResourceTypeTests.swift */; };
 		EA00EEB31F8D293C00166ABA /* NetworkPropertyListDecodableResourceTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00EEB21F8D293C00166ABA /* NetworkPropertyListDecodableResourceTypeTests.swift */; };
 		EA1EE0C81F87DD8500902527 /* JSONDecodableResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1EE0C71F87DD8500902527 /* JSONDecodableResourceType.swift */; };
@@ -167,6 +168,7 @@
 		4FF581741F051F23008D0A20 /* Result+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+Additions.swift"; sourceTree = "<group>"; };
 		4FFA60A41D9C017200A91693 /* NetworkJSONDictionaryResourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkJSONDictionaryResourceType.swift; sourceTree = "<group>"; };
 		5F26A0A11FED1F6A0075BDFD /* URLSession+URLSessionTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+URLSessionTypeTests.swift"; sourceTree = "<group>"; };
+		90B62B47223A5F6C00640CE9 /* CharacterSet+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CharacterSet+Additions.swift"; sourceTree = "<group>"; };
 		EA00EEAF1F8D27D900166ABA /* NetworkJSONDecodableResourceTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkJSONDecodableResourceTypeTests.swift; sourceTree = "<group>"; };
 		EA00EEB21F8D293C00166ABA /* NetworkPropertyListDecodableResourceTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPropertyListDecodableResourceTypeTests.swift; sourceTree = "<group>"; };
 		EA1EE0C71F87DD8500902527 /* JSONDecodableResourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodableResourceType.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				4F4BE52B1ECB415500C2CC56 /* String+Error.swift */,
 				EA1EE0D41F881CF000902527 /* String+Additions.swift */,
 				4FF581741F051F23008D0A20 /* Result+Additions.swift */,
+				90B62B47223A5F6C00640CE9 /* CharacterSet+Additions.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -703,6 +706,7 @@
 				4F079D2C1D84577E00D08DA0 /* JSONParsingError.swift in Sources */,
 				4FBC07481E4F67F200D14EBA /* NetworkResponseHandler.swift in Sources */,
 				4F079D2A1D84577E00D08DA0 /* DataResourceType.swift in Sources */,
+				90B62B48223A5F6C00640CE9 /* CharacterSet+Additions.swift in Sources */,
 				4FF005331DC9F985006BBACE /* ResourceType.swift in Sources */,
 				4FD11C011E3A6A99004C7B0A /* NetworkServiceActivity.swift in Sources */,
 				EA1EE0CA1F87DE6600902527 /* PropertyListDecodableResourceType.swift in Sources */,

--- a/Tests/TABResourceLoaderTests/Helpers/CharacterSet+Additions.swift
+++ b/Tests/TABResourceLoaderTests/Helpers/CharacterSet+Additions.swift
@@ -1,0 +1,18 @@
+//
+//  CharacterSet+Additions.swift
+//  TABResourceLoader
+//
+//  Created by Marco Guerrieri on 14/03/2019.
+//  Copyright © 2019 Luciano Marisi. All rights reserved.
+//
+
+import Foundation
+
+extension CharacterSet {
+  public static var improvedUrlQueryAllowed: CharacterSet {
+    var miniUrlQueryAllowed = CharacterSet.urlQueryAllowed
+    miniUrlQueryAllowed.remove("&")
+    miniUrlQueryAllowed.remove("=")
+    return miniUrlQueryAllowed
+  }
+}

--- a/Tests/TABResourceLoaderTests/Helpers/CharacterSet+Additions.swift
+++ b/Tests/TABResourceLoaderTests/Helpers/CharacterSet+Additions.swift
@@ -11,8 +11,8 @@ import Foundation
 extension CharacterSet {
   public static var improvedUrlQueryAllowed: CharacterSet {
     var characterSet = CharacterSet.urlQueryAllowed
-    characterSet("&")
-    characterSet("=")
+    characterSet.remove("&")
+    characterSet.remove("=")
     return characterSet
   }
 }

--- a/Tests/TABResourceLoaderTests/Helpers/CharacterSet+Additions.swift
+++ b/Tests/TABResourceLoaderTests/Helpers/CharacterSet+Additions.swift
@@ -10,9 +10,9 @@ import Foundation
 
 extension CharacterSet {
   public static var improvedUrlQueryAllowed: CharacterSet {
-    var miniUrlQueryAllowed = CharacterSet.urlQueryAllowed
-    miniUrlQueryAllowed.remove("&")
-    miniUrlQueryAllowed.remove("=")
-    return miniUrlQueryAllowed
+    var characterSet = CharacterSet.urlQueryAllowed
+    characterSet("&")
+    characterSet("=")
+    return characterSet
   }
 }

--- a/Tests/TABResourceLoaderTests/Mocks/MockJSONDictionaryResourceType.swift
+++ b/Tests/TABResourceLoaderTests/Mocks/MockJSONDictionaryResourceType.swift
@@ -12,7 +12,7 @@ import Foundation
 struct MockJSONDictionaryResourceType: JSONDictionaryResourceType {
   typealias Model = MockObject
 
-  func model(from jsonDictionary: [String : Any]) throws -> MockObject {
+  func model(from jsonDictionary: [String: Any]) throws -> MockObject {
     guard let mock = MockObject(jsonDictionary: jsonDictionary) else {
       throw JSONParsingError.cannotParseJSONDictionary
     }

--- a/Tests/TABResourceLoaderTests/Mocks/MockObject.swift
+++ b/Tests/TABResourceLoaderTests/Mocks/MockObject.swift
@@ -13,7 +13,7 @@ struct MockObject: Decodable {
 }
 
 extension MockObject {
-  init?(jsonDictionary: [String : Any]) {
+  init?(jsonDictionary: [String: Any]) {
     guard let parsedName = jsonDictionary["name"] as? String else {
       return nil
     }

--- a/Tests/TABResourceLoaderTests/Mocks/MockResourceService.swift
+++ b/Tests/TABResourceLoaderTests/Mocks/MockResourceService.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import TABResourceLoader
 
 class MockSessionThatDoesNothing: URLSessionType {
-  
+
   public func perform(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
     return URLSessionDataTask()
   }

--- a/Tests/TABResourceLoaderTests/Mocks/MockURLSession.swift
+++ b/Tests/TABResourceLoaderTests/Mocks/MockURLSession.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import TABResourceLoader
 
 final class MockURLSession: URLSessionType {
-  
+
   typealias URLSessionCompletionHandler = (Data?, URLResponse?, Error?) -> Void
 
   var capturedRequest: URLRequest?
@@ -26,6 +26,6 @@ final class MockURLSession: URLSessionType {
   func invalidateAndCancel() {
     invalidateAndCancelCallCount += 1
   }
-  
+
  func cancelAllRequests() { /* not implemented */ }
 }

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkJSONDictionaryResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkJSONDictionaryResourceTypeTests.swift
@@ -13,7 +13,7 @@ struct MockNetworkJSONDictionaryResourceType: NetworkJSONDictionaryResourceType 
   typealias Model = String
   let url: URL
 
-  func model(from jsonDictionary: [String : Any]) throws -> String {
+  func model(from jsonDictionary: [String: Any]) throws -> String {
     return ""
   }
 

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -107,10 +107,20 @@ class NetworkResourceTypeTests: XCTestCase {
   }
 
   func test_urlRequest_resourceURLWithQueryParametersWithEmptyParameter() {
-    let mockedURLQueryItems = [URLQueryItem(name: "query:with+another-name", value: "")]
+    let mockedURLQueryItems = [URLQueryItem(name: "query-name", value: "")]
     let resource = MockCustomNetworkResource(url: urlWithQueryItem, queryItems: mockedURLQueryItems)
 
-    let expectedURLString = "\(urlWithQueryItem)&query:with+another-name="
+    let expectedURLString = "\(urlWithQueryItem)&query-name="
+    let urlRequest = resource.urlRequest()
+
+    XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)
+  }
+
+  func test_urlRequest_resourceURLWithQueryParametersWithMalformedParameter() {
+    let mockedURLQueryItems = [URLQueryItem(name: "query-name", value: "malformed&value")]
+    let resource = MockCustomNetworkResource(url: urlWithQueryItem, queryItems: mockedURLQueryItems)
+
+    let expectedURLString = "\(urlWithQueryItem)&query-name=malformed&value"
     let urlRequest = resource.urlRequest()
 
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -116,11 +116,11 @@ class NetworkResourceTypeTests: XCTestCase {
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)
   }
 
-  func test_urlRequest_resourceURLWithQueryParametersWithAmpAndEquals() {
+  func test_urlRequest_resourceURLWithQueryParametersWithAmpAndEqual() {
     let mockedURLQueryItems = [URLQueryItem(name: "query-name", value: "malformed&value=something")]
     let resource = MockCustomNetworkResource(url: urlWithQueryItem, queryItems: mockedURLQueryItems)
 
-    let expectedURLString = "\(urlWithQueryItem)&query-name=malformed%26value=%3Dsomething"
+    let expectedURLString = "\(urlWithQueryItem)&query-name=malformed%26value%3Dsomething"
     let urlRequest = resource.urlRequest()
 
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -106,6 +106,16 @@ class NetworkResourceTypeTests: XCTestCase {
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)
   }
 
+  func test_urlRequest_resourceURLWithQueryParametersWithEmptyParameter() {
+    let mockedURLQueryItems = [URLQueryItem(name: "query:with+another-name", value: "")]
+    let resource = MockCustomNetworkResource(url: urlWithQueryItem, queryItems: mockedURLQueryItems)
+
+    let expectedURLString = "\(urlWithQueryItem)&query:with+another-name="
+    let urlRequest = resource.urlRequest()
+
+    XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)
+  }
+
   func test_urlRequest_resourceURLWithNoQueryItemsHasNoQuestionMark() {
     let urlWithQueryParameters = URL(string: "www.test.com")!
     let resource = MockCustomNetworkResource(url: urlWithQueryParameters)

--- a/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Protocols/NetworkResourceTypeTests.swift
@@ -24,7 +24,7 @@ private struct MockCustomNetworkResource: NetworkResourceType {
   let requestTimeoutInterval: TimeInterval? = 27
   let urlQueryAllowedCharacterSet: CharacterSet
 
-  init(url: URL, httpRequestMethod: HTTPMethod = .get, httpHeaderFields: [String: String]? = nil, jsonBody: Any? = nil, queryItems: [URLQueryItem]? = nil, urlQueryAllowedCharacterSet: CharacterSet = .urlQueryAllowed) {
+  init(url: URL, httpRequestMethod: HTTPMethod = .get, httpHeaderFields: [String: String]? = nil, jsonBody: Any? = nil, queryItems: [URLQueryItem]? = nil, urlQueryAllowedCharacterSet: CharacterSet = .improvedUrlQueryAllowed) {
     self.url = url
     self.httpRequestMethod = httpRequestMethod
     self.httpHeaderFields = httpHeaderFields
@@ -116,11 +116,11 @@ class NetworkResourceTypeTests: XCTestCase {
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)
   }
 
-  func test_urlRequest_resourceURLWithQueryParametersWithMalformedParameter() {
-    let mockedURLQueryItems = [URLQueryItem(name: "query-name", value: "malformed&value")]
+  func test_urlRequest_resourceURLWithQueryParametersWithAmpAndEquals() {
+    let mockedURLQueryItems = [URLQueryItem(name: "query-name", value: "malformed&value=something")]
     let resource = MockCustomNetworkResource(url: urlWithQueryItem, queryItems: mockedURLQueryItems)
 
-    let expectedURLString = "\(urlWithQueryItem)&query-name=malformed&value"
+    let expectedURLString = "\(urlWithQueryItem)&query-name=malformed%26value=%3Dsomething"
     let urlRequest = resource.urlRequest()
 
     XCTAssertEqual(urlRequest?.url?.absoluteString, expectedURLString)

--- a/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/NetworkDataResourceServiceTests.swift
@@ -224,7 +224,7 @@ class NetworkDataResourceServiceTests: XCTestCase {
     }
     waitForExpectation()
   }
-  
+
   func testCancelAllRequests() {
     testService = GenericNetworkDataResourceService<MockDefaultNetworkDataResource>()
     performAsyncTest { expectation in

--- a/Tests/TABResourceLoaderTests/Services/URLSession+URLSessionTypeTests.swift
+++ b/Tests/TABResourceLoaderTests/Services/URLSession+URLSessionTypeTests.swift
@@ -10,13 +10,13 @@ import XCTest
 import TABResourceLoader
 
 class URLSessionTests: XCTestCase {
-    
+
   func testCancelAllRequests() {
     let config = URLSessionConfiguration.default
     let urlSession = URLSession(configuration: config)
     let url = URL(string: "https://www.test.com")!
     let wait = expectation(description: "URLSession cancels request")
-    let dataTask = urlSession.dataTask(with: url) { (data, response, error) in
+    let dataTask = urlSession.dataTask(with: url) { (_, _, error) in
       guard let error = error else {
         XCTFail("Did not receive expected cancellation error")
         return


### PR DESCRIPTION
Added possibility to set urlQueryAllowedCharacterSet, the CharacterSet used to decide from the Library what and whatnot percent-encode. Default value will be query url default allowed characters CharacterSet.urlQueryAllowed